### PR TITLE
Unfinished event mechanism for EpollEventLoop

### DIFF
--- a/source/eventcore/drivers/posix/driver.d
+++ b/source/eventcore/drivers/posix/driver.d
@@ -91,7 +91,7 @@ final class PosixEventDriver(Loop : PosixEventLoop) : EventDriver {
 	{
 		m_files.dispose();
 		m_dns.dispose();
-		m_loop.dispose();		
+		m_loop.dispose();
 	}
 }
 
@@ -221,11 +221,12 @@ package class PosixEventLoop {
 	/// Updates the event mask to use for listening for notifications.
 	protected abstract void updateFD(FD fd, EventMask old_mask, EventMask new_mask);
 
-	final protected void notify(EventType evt)(FD fd)
+	final protected bool notify(EventType evt)(FD fd)
 	{
 		//assert(m_fds[fd].callback[evt] !is null, "Notifying FD which is not listening for event.");
 		if (m_fds[fd.value].common.callback[evt])
-			m_fds[fd.value].common.callback[evt](fd);
+			return m_fds[fd.value].common.callback[evt](fd);
+		return false;
 	}
 
 	final protected void enumerateFDs(EventType evt)(scope FDEnumerateCallback del)
@@ -276,7 +277,7 @@ package class PosixEventLoop {
 
 alias FDEnumerateCallback = void delegate(FD);
 
-alias FDSlotCallback = void delegate(FD);
+alias FDSlotCallback = bool delegate(FD);
 
 private struct FDSlot {
 	FDSlotCallback[EventType.max+1] callback;

--- a/source/eventcore/drivers/posix/epoll.d
+++ b/source/eventcore/drivers/posix/epoll.d
@@ -91,7 +91,7 @@ final class EpollEventLoop : PosixEventLoop {
 
 		if (ret > 0) {
 			processed_any = true;
-			foreach (i, ref evt; m_events[0 .. ret]) {
+			foreach (ref evt; m_events[0 .. ret]) {
 				debug (EventCoreEpollDebug) print("Epoll event on %s: %s", evt.data.fd, evt.events);
 				UnfinishedRecord ur;
 				auto fd = cast(FD)evt.data.fd;

--- a/source/eventcore/drivers/posix/epoll.d
+++ b/source/eventcore/drivers/posix/epoll.d
@@ -57,7 +57,7 @@ final class EpollEventLoop : PosixEventLoop {
 
 	override bool doProcessEvents(Duration timeout)
 	@trusted {
-		import std.algorithm : min, max, remove, SwapStrategy;
+		import std.algorithm : min, max, remove, canFind, SwapStrategy;
 		//assert(Fiber.getThis() is null, "processEvents may not be called from within a fiber!");
 
 		debug (EventCoreEpollDebug) print("Epoll wait %s, %s", m_events.length, timeout);
@@ -102,8 +102,10 @@ final class EpollEventLoop : PosixEventLoop {
 				if (evt.events & EPOLLOUT)
 					ur.write_unfinished = notify!(EventType.write)(fd);
 				if (!ur.all_finished) {
-					ur.fd = fd;
-					unfinished_events ~= ur;
+					if (!unfinished_events.canFind!(a => a.fd == fd)()) {
+						ur.fd = fd;
+						unfinished_events ~= ur;
+					}
 				}
 			}
 		}

--- a/source/eventcore/drivers/posix/epoll.d
+++ b/source/eventcore/drivers/posix/epoll.d
@@ -18,23 +18,46 @@ import core.sys.linux.epoll;
 
 alias EpollEventDriver = PosixEventDriver!EpollEventLoop;
 
+
 final class EpollEventLoop : PosixEventLoop {
 @safe: nothrow:
 
 	private {
 		int m_epoll;
 		epoll_event[] m_events;
+
+		struct UnfinishedRecord
+		{
+			bool status_unfinished;
+			bool read_unfinished;
+			bool write_unfinished;
+			FD fd;	// file to process on next loop
+			bool all_finished() nothrow @safe
+			{
+				return !(status_unfinished || read_unfinished || write_unfinished);
+			}
+		}
+
+		// some files may exhibit explosive event generation patters.
+		// TCP socket is perfect example. When thousand of new connections is
+		// established, we may never leave onAccept handler, if we don't limit
+		// event count. If we do though, we are left with buffered connection
+		// requests wich will not be handled until next epoll event. In order to
+		// increase fairness we let notify method of PosixEventLoop to report
+		// wheter event still requires processing.
+		UnfinishedRecord[] unfinished_events;
 	}
 
 	this()
 	{
 		m_epoll = () @trusted { return epoll_create1(0); } ();
 		m_events.length = 100;
+		unfinished_events.reserve(100);
 	}
 
 	override bool doProcessEvents(Duration timeout)
 	@trusted {
-		import std.algorithm : min, max;
+		import std.algorithm : min, max, remove, SwapStrategy;
 		//assert(Fiber.getThis() is null, "processEvents may not be called from within a fiber!");
 
 		debug (EventCoreEpollDebug) print("Epoll wait %s, %s", m_events.length, timeout);
@@ -44,16 +67,48 @@ final class EpollEventLoop : PosixEventLoop {
 		auto ret = epoll_wait(m_epoll, m_events.ptr, cast(int)m_events.length, tomsec > int.max ? -1 : cast(int)tomsec);
 		debug (EventCoreEpollDebug) print("Epoll wait done: %s", ret);
 
-		if (ret > 0) {
-			foreach (ref evt; m_events[0 .. ret]) {
-				debug (EventCoreEpollDebug) print("Epoll event on %s: %s", evt.data.fd, evt.events);
-				auto fd = cast(FD)evt.data.fd;
-				if (evt.events & (EPOLLERR|EPOLLHUP|EPOLLRDHUP)) notify!(EventType.status)(fd);
-				if (evt.events & EPOLLIN) notify!(EventType.read)(fd);
-				if (evt.events & EPOLLOUT) notify!(EventType.write)(fd);
+		bool processed_any = false;
+
+		// we finish what we didn't do in previous handling cycle
+		if (unfinished_events.length)
+		{
+			processed_any = true;
+			debug (EventCoreEpollDebug) print("Epoll unfinished cycle");
+			foreach (ref unf; unfinished_events)
+			{
+				auto fd = unf.fd;
+				if (unf.status_unfinished)
+					unf.status_unfinished = notify!(EventType.status)(fd);
+				if (unf.read_unfinished)
+					unf.read_unfinished = notify!(EventType.read)(fd);
+				if (unf.write_unfinished)
+					unf.write_unfinished = notify!(EventType.write)(fd);
 			}
-			return true;
-		} else return false;
+			// remove all records that were served
+			unfinished_events =
+				remove!(u => u.all_finished, SwapStrategy.unstable)(unfinished_events);
+		}
+
+		if (ret > 0) {
+			processed_any = true;
+			foreach (i, ref evt; m_events[0 .. ret]) {
+				debug (EventCoreEpollDebug) print("Epoll event on %s: %s", evt.data.fd, evt.events);
+				UnfinishedRecord ur;
+				auto fd = cast(FD)evt.data.fd;
+				if (evt.events & (EPOLLERR|EPOLLHUP|EPOLLRDHUP))
+					ur.status_unfinished = notify!(EventType.status)(fd);
+				if (evt.events & EPOLLIN)
+					ur.read_unfinished = notify!(EventType.read)(fd);
+				if (evt.events & EPOLLOUT)
+					ur.write_unfinished = notify!(EventType.write)(fd);
+				if (!ur.all_finished) {
+					ur.fd = fd;
+					unfinished_events ~= ur;
+				}
+			}
+		}
+
+		return processed_any;
 	}
 
 	override void dispose()

--- a/source/eventcore/drivers/posix/events.d
+++ b/source/eventcore/drivers/posix/events.d
@@ -105,7 +105,7 @@ final class PosixEventDriverEvents(Loop : PosixEventLoop, Sockets : EventDriverS
 		getSlot(event).waiters.removePending(on_event);
 	}
 
-	private void onEvent(FD fd)
+	private bool onEvent(FD fd)
 	@trusted {
 		EventID event = cast(EventID)fd;
 		version (linux) {
@@ -115,6 +115,7 @@ final class PosixEventDriverEvents(Loop : PosixEventLoop, Sockets : EventDriverS
 		import core.atomic : cas;
 		auto all = cas(&getSlot(event).triggerAll, true, false);
 		trigger(event, all);
+		return false;
 	}
 
 	version (linux) {}

--- a/source/eventcore/drivers/posix/sockets.d
+++ b/source/eventcore/drivers/posix/sockets.d
@@ -180,7 +180,7 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 
 	private void onAccept(FD listenfd)
 	{
-		foreach (i; 0 .. 20) {
+		while (true) {
 			sock_t sockfd;
 			sockaddr_storage addr;
 			socklen_t addr_len = addr.sizeof;
@@ -802,4 +802,3 @@ private int getSocketError()
 	version (Windows) return WSAGetLastError();
 	else return errno;
 }
-

--- a/source/eventcore/drivers/posix/sockets.d
+++ b/source/eventcore/drivers/posix/sockets.d
@@ -104,7 +104,7 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 		return fd;
 	}
 
-	private void onConnect(FD sock)
+	private bool onConnect(FD sock)
 	{
 		m_loop.setNotifyCallback!(EventType.write)(sock, null);
 		with (m_loop.m_fds[sock].streamSocket) {
@@ -113,9 +113,10 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 			connectCallback = null;
 			if (cb) cb(cast(StreamSocketFD)sock, ConnectStatus.connected);
 		}
+		return false;
 	}
 
-	private void onConnectError(FD sock)
+	private bool onConnectError(FD sock)
 	{
 		// FIXME: determine the correct kind of error!
 		with (m_loop.m_fds[sock].streamSocket) {
@@ -124,6 +125,7 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 			connectCallback = null;
 			if (cb) cb(cast(StreamSocketFD)sock, ConnectStatus.refused);
 		}
+		return false;
 	}
 
 	alias listenStream = EventDriverSockets.listenStream;
@@ -174,18 +176,23 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 	{
 		m_loop.registerFD(sock, EventMask.read);
 		m_loop.m_fds[sock].streamListen.acceptCallback = on_accept;
-		m_loop.setNotifyCallback!(EventType.read)(sock, &onAccept);
-		onAccept(sock);
+		m_loop.setNotifyCallback!(EventType.read)(sock, &onAccept!true);
+		onAccept!(false)(sock);
 	}
 
-	private void onAccept(FD listenfd)
+	// returns true when there mey be unaccepted connections left
+	private bool onAccept(bool limit_accepts = true)(FD listenfd)
 	{
+		static if (limit_accepts)
+			int con_accepted = 0;
+
 		while (true) {
 			sock_t sockfd;
 			sockaddr_storage addr;
 			socklen_t addr_len = addr.sizeof;
 			() @trusted { sockfd = accept(cast(sock_t)listenfd, () @trusted { return cast(sockaddr*)&addr; } (), &addr_len); } ();
-			if (sockfd == -1) break;
+			if (sockfd == -1)
+				return false;
 
 			setSocketNonBlocking(cast(SocketFD)sockfd);
 			auto fd = cast(StreamSocketFD)sockfd;
@@ -198,6 +205,12 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 			//print("accept %d", sockfd);
 			scope RefAddress addrc = new RefAddress(() @trusted { return cast(sockaddr*)&addr; } (), addr_len);
 			m_loop.m_fds[listenfd].streamListen.acceptCallback(cast(StreamListenSocketFD)listenfd, fd, addrc);
+
+			static if (limit_accepts)
+			{
+				if (++con_accepted >= 64)
+					return true;
+			}
 		}
 	}
 
@@ -296,7 +309,7 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 		}
 	}
 
-	private void onSocketRead(FD fd)
+	private bool onSocketRead(FD fd)
 	{
 		auto slot = () @trusted { return &m_loop.m_fds[fd].streamSocket(); } ();
 		auto socket = cast(StreamSocketFD)fd;
@@ -314,14 +327,14 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 			auto err = getSocketError();
 			if (!err.among!(EAGAIN, EINPROGRESS)) {
 				finalize(IOStatus.error);
-				return;
+				return false;
 			}
 		}
 
 		if (ret == 0 && slot.readBuffer.length) {
 			slot.state = ConnectionState.passiveClose;
 			finalize(IOStatus.disconnected);
-			return;
+			return false;
 		}
 
 		if (ret > 0 || !slot.readBuffer.length) {
@@ -329,9 +342,10 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 			slot.readBuffer = slot.readBuffer[ret .. $];
 			if (slot.readMode != IOMode.all || slot.readBuffer.length == 0) {
 				finalize(IOStatus.ok);
-				return;
+				return false;
 			}
 		}
+		return false;
 	}
 
 	final override void write(StreamSocketFD socket, const(ubyte)[] buffer, IOMode mode, IOCallback on_write_finish)
@@ -389,7 +403,7 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 		m_loop.m_fds[socket].streamSocket.writeBuffer = null;
 	}
 
-	private void onSocketWrite(FD fd)
+	private bool onSocketWrite(FD fd)
 	{
 		auto slot = () @trusted { return &m_loop.m_fds[fd].streamSocket(); } ();
 		auto socket = cast(StreamSocketFD)fd;
@@ -402,7 +416,7 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 			if (!err.among!(EAGAIN, EINPROGRESS)) {
 				m_loop.setNotifyCallback!(EventType.write)(socket, null);
 				slot.writeCallback(socket, IOStatus.error, slot.bytesRead);
-				return;
+				return false;
 			}
 		}
 
@@ -412,9 +426,10 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 			if (slot.writeMode != IOMode.all || slot.writeBuffer.length == 0) {
 				m_loop.setNotifyCallback!(EventType.write)(socket, null);
 				slot.writeCallback(cast(StreamSocketFD)socket, IOStatus.ok, slot.bytesWritten);
-				return;
+				return false;
 			}
 		}
+		return false;
 	}
 
 	final override void waitForData(StreamSocketFD socket, IOCallback on_data_available)
@@ -453,7 +468,7 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 		m_loop.setNotifyCallback!(EventType.read)(socket, &onSocketDataAvailable);
 	}
 
-	private void onSocketDataAvailable(FD fd)
+	private bool onSocketDataAvailable(FD fd)
 	{
 		auto slot = () @trusted { return &m_loop.m_fds[fd].streamSocket(); } ();
 		auto socket = cast(StreamSocketFD)fd;
@@ -472,6 +487,8 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 			auto err = getSocketError();
 			if (!err.among!(EAGAIN, EINPROGRESS)) finalize(IOStatus.error);
 		} else finalize(ret ? IOStatus.ok : IOStatus.disconnected);
+
+		return false;
 	}
 
 	final override void shutdown(StreamSocketFD socket, bool shut_read, bool shut_write)
@@ -595,7 +612,7 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 		m_loop.m_fds[socket].datagramSocket.readBuffer = null;
 	}
 
-	private void onDgramRead(FD fd)
+	private bool onDgramRead(FD fd)
 	@trusted { // DMD 2.072.0-b2: scope considered unsafe
 		auto slot = () @trusted { return &m_loop.m_fds[fd].datagramSocket(); } ();
 		auto socket = cast(DatagramSocketFD)fd;
@@ -610,13 +627,14 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 			if (!err.among!(EAGAIN, EINPROGRESS)) {
 				m_loop.setNotifyCallback!(EventType.read)(socket, null);
 				slot.readCallback(socket, IOStatus.error, 0, null);
-				return;
+				return false;
 			}
 		}
 
 		m_loop.setNotifyCallback!(EventType.read)(socket, null);
 		scope src_addrc = new RefAddress(() @trusted { return cast(sockaddr*)&src_addr; } (), src_addr.sizeof);
 		() @trusted { return cast(DatagramIOCallback)slot.readCallback; } ()(socket, IOStatus.ok, ret, src_addrc);
+		return false;
 	}
 
 	void send(DatagramSocketFD socket, const(ubyte)[] buffer, IOMode mode, Address target_address, DatagramIOCallback on_send_finish)
@@ -664,7 +682,7 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 		m_loop.m_fds[socket].datagramSocket.writeBuffer = null;
 	}
 
-	private void onDgramWrite(FD fd)
+	private bool onDgramWrite(FD fd)
 	{
 		auto slot = () @trusted { return &m_loop.m_fds[fd].datagramSocket(); } ();
 		auto socket = cast(DatagramSocketFD)fd;
@@ -681,12 +699,14 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 			if (!err.among!(EAGAIN, EINPROGRESS)) {
 				m_loop.setNotifyCallback!(EventType.write)(socket, null);
 				() @trusted { return cast(DatagramIOCallback)slot.writeCallback; } ()(socket, IOStatus.error, 0, null);
-				return;
+				return false;
 			}
 		}
 
 		m_loop.setNotifyCallback!(EventType.write)(socket, null);
 		() @trusted { return cast(DatagramIOCallback)slot.writeCallback; } ()(socket, IOStatus.ok, ret, null);
+
+		return false;
 	}
 
 	final override void addRef(SocketFD fd)

--- a/source/eventcore/drivers/posix/watchers.d
+++ b/source/eventcore/drivers/posix/watchers.d
@@ -70,9 +70,10 @@ final class InotifyEventDriverWatchers(Loop : PosixEventLoop) : EventDriverWatch
 		return true;
 	}
 
-	private void onChanges(FD fd)
+	private bool onChanges(FD fd)
 	{
 		processEvents(cast(WatcherID)fd);
+		return false;
 	}
 
 	private void processEvents(WatcherID id)


### PR DESCRIPTION
Long story short:

I siege-tested vibe-d http service and started to see what I thought to be deadlocks.
When service was bombarded with 256 and more simultaneous tcp connection requests, only some of them were served (first hudred or so), and after that service was not answering (seemingly). Logs showed, that this strange state was buffer-alike. I curled the same request to it a couple of times and it passed after 3 or 4 times, each time a significant portion of unprocessed requests, born during the siege, showed in server logs, until all were processed.

After some detective work I saw this line:
https://github.com/vibe-d/eventcore/blob/master/source/eventcore/drivers/posix/sockets.d#L183

Obviously, original idea was to prevent event loop blocking on non-stop accept requests. This way, unfortunately, leaves requests wich arrived in one spike, partially unserved.

This pull request is my crutch, wich I'll use in prod due to lack of time. It creates a registry inside of EpollEventLoop wich will record all file descriptors, wich were not fully served during previous doProcessEvents call. Handlers for those descriptors will be notified again on next loop, regardless of epoll socket event presence.

I tested it. It works and solves my problem with TCP sockets accept. Behaviour of other handlers is not modified in this PR.