### PR TITLE
Avoid "." path in InotifyEventDriverWatchers.

### DIFF
--- a/source/eventcore/drivers/posix/watchers.d
+++ b/source/eventcore/drivers/posix/watchers.d
@@ -41,7 +41,7 @@ final class InotifyEventDriverWatchers(Events : EventDriverEvents) : EventDriver
 
 		m_watches[ret] = WatchState(null, path, recursive);
 
-		addWatch(ret, path, ".");
+		addWatch(ret, path, "");
 		if (recursive) {
 			try {
 				auto base_segements = path.pathSplitter.walkLength;
@@ -138,7 +138,7 @@ final class InotifyEventDriverWatchers(Events : EventDriverEvents) : EventDriver
 				auto subdir = w.watcherPaths[ev.wd];
 
 				if (w.recursive && ev.mask & (IN_CREATE|IN_MOVED_TO) && ev.mask & IN_ISDIR) {
-					addWatch(id, w.basePath, subdir == "." ? name.idup : buildPath(subdir, name));
+					addWatch(id, w.basePath, subdir == "" ? name.idup : buildPath(subdir, name));
 				}
 
 				ch.baseDirectory = m_watches[id].basePath;

--- a/source/eventcore/drivers/winapi/watchers.d
+++ b/source/eventcore/drivers/winapi/watchers.d
@@ -123,6 +123,7 @@ final class WinAPIEventDriverWatchers : EventDriverWatchers {
 			auto path = () @trusted { scope (failure) assert(false); return to!string(fni.FileName[0 .. fni.FileNameLength/2]); } ();
 			auto fullpath = buildPath(slot.directory, path);
 			ch.directory = dirName(path);
+			if (ch.directory == ".") ch.directory = "";
 			ch.name = baseName(path);
 			try ch.isDirectory = isDir(fullpath);
 			catch (Exception e) {} // FIXME: can happen if the base path is relative and the CWD has changed

--- a/tests/0-dirwatcher-rec.d
+++ b/tests/0-dirwatcher-rec.d
@@ -160,5 +160,7 @@ print("test %s RENAME %s %s", from, to, expect_change);
 
 FileChange fchange(FileChangeKind kind, string name, bool is_dir)
 {
-	return FileChange(kind, testDir, dirName(name), baseName(name), is_dir);
+	auto dn = dirName(name);
+	if (dn == ".") dn = "";
+	return FileChange(kind, testDir, dn, baseName(name), is_dir);
 }

--- a/tests/0-dirwatcher.d
+++ b/tests/0-dirwatcher.d
@@ -27,17 +27,20 @@ void main()
 			default: assert(false);
 			case 0:
 				assert(change.kind == FileChangeKind.added);
-				assert(change.directory == ".");
+				assert(change.baseDirectory == ".");
+				assert(change.directory == "");
 				assert(change.name == testFilename);
 				break;
 			case 1:
 				assert(change.kind == FileChangeKind.modified);
-				assert(change.directory == ".");
+				assert(change.baseDirectory == ".");
+				assert(change.directory == "");
 				assert(change.name == testFilename);
 				break;
 			case 2:
 				assert(change.kind == FileChangeKind.removed);
-				assert(change.directory == ".");
+				assert(change.baseDirectory == ".");
+				assert(change.directory == "");
 				assert(change.name == testFilename);
 				eventDriver.watchers.releaseRef(id);
 				s_done = true;


### PR DESCRIPTION
The vibe-core tests broke because a "/./" path segment slipped into the resulting paths.