### PR TITLE
Call Windows IO callbacks outside of completion routines.

### DIFF
--- a/source/eventcore/drivers/winapi/core.d
+++ b/source/eventcore/drivers/winapi/core.d
@@ -225,7 +225,7 @@ private struct HandleSlot {
 
 package struct FileSlot {
 	static struct Direction(bool RO) {
-		OVERLAPPED_FILE overlapped;
+		OVERLAPPED_CORE overlapped;
 		FileIOCallback callback;
 		ulong offset;
 		size_t bytesTransferred;
@@ -238,7 +238,7 @@ package struct FileSlot {
 			auto cb = this.callback;
 			this.callback = null;
 			assert(cb !is null);
-			cb(overlapped.handle, status, bytes_transferred);
+			cb(cast(FileFD)cast(size_t)overlapped.hEvent, status, bytes_transferred);
 		}
 	}
 	Direction!false read;
@@ -257,12 +257,6 @@ package struct OVERLAPPED_CORE {
 	OVERLAPPED overlapped;
 	alias overlapped this;
 	WinAPIEventDriverCore driver;
-}
-
-package struct OVERLAPPED_FILE {
-	OVERLAPPED_CORE core;
-	alias core this;
-	FileFD handle;
 }
 
 package struct IOEvent {

--- a/source/eventcore/internal/win32.d
+++ b/source/eventcore/internal/win32.d
@@ -30,6 +30,8 @@ enum {
 	MAX_PROTOCOL_CHAIN = 7,
 }
 
+enum WSAEDISCON = 10101;
+
 enum WSA_OPERATION_ABORTED = 995;
 enum WSA_IO_PENDING = 997;
 
@@ -153,7 +155,7 @@ void freeaddrinfo(ADDRINFOA* ai);
 BOOL TransmitFile(SOCKET hSocket, HANDLE hFile, DWORD nNumberOfBytesToWrite, DWORD nNumberOfBytesPerSend, OVERLAPPED* lpOverlapped, LPTRANSMIT_FILE_BUFFERS lpTransmitBuffers, DWORD dwFlags);
 BOOL CancelIoEx(HANDLE hFile, LPOVERLAPPED lpOverlapped);
 
-struct WSAOVERLAPPEDX {
+/*struct WSAOVERLAPPEDX {
 	ULONG_PTR Internal;
 	ULONG_PTR InternalHigh;
 	union {
@@ -164,4 +166,6 @@ struct WSAOVERLAPPEDX {
 		PVOID  Pointer;
 	}
 	HANDLE hEvent;
-}
+}*/
+
+alias WSAOVERLAPPEDX = OVERLAPPED;


### PR DESCRIPTION
Calling WinSock functions from inside of a completion routine results in undefined behavior, because the completion routine may be triggered within another WinSock function that enters an alertable wait state. For this reason, none of the callbacks that are triggered by overlapped I/O may be invoked directly from a completion routine.

To solve this, a ConsumableQueue is filled with all completion events that occur and is processed after each MsgWaitForMultipleObjectsEx call.