### PR TITLE
Use a custom nogc_assert in cleanup code.

### DIFF
--- a/source/eventcore/drivers/posix/signals.d
+++ b/source/eventcore/drivers/posix/signals.d
@@ -3,6 +3,7 @@ module eventcore.drivers.posix.signals;
 
 import eventcore.driver;
 import eventcore.drivers.posix.driver;
+import eventcore.internal.utils : nogc_assert;
 
 import std.algorithm.comparison : among;
 
@@ -56,7 +57,7 @@ final class SignalFDEventDriverSignals(Loop : PosixEventLoop) : EventDriverSigna
 	override bool releaseRef(SignalListenID descriptor)
 	{
 		FD fd = cast(FD)descriptor;
-		assert(m_loop.m_fds[fd].common.refCount > 0, "Releasing reference to unreferenced event FD.");
+		nogc_assert(m_loop.m_fds[fd].common.refCount > 0, "Releasing reference to unreferenced event FD.");
 		if (--m_loop.m_fds[fd].common.refCount == 1) { // NOTE: 1 because setNotifyCallback adds a second reference
 			m_loop.unregisterFD(fd, EventMask.read);
 			m_loop.clearFD(fd);

--- a/source/eventcore/drivers/posix/sockets.d
+++ b/source/eventcore/drivers/posix/sockets.d
@@ -804,7 +804,7 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 	{
 		import taggedalgebraic : hasType;
 		auto slot = () @trusted { return &m_loop.m_fds[fd]; } ();
-		assert(slot.common.refCount > 0, "Releasing reference to unreferenced socket FD.");
+		nogc_assert(slot.common.refCount > 0, "Releasing reference to unreferenced socket FD.");
 		// listening sockets have an incremented the reference count because of setNotifyCallback
 		int base_refcount = slot.specific.hasType!StreamListenSocketSlot ? 1 : 0;
 		if (--slot.common.refCount == base_refcount) {

--- a/source/eventcore/drivers/posix/watchers.d
+++ b/source/eventcore/drivers/posix/watchers.d
@@ -3,6 +3,7 @@ module eventcore.drivers.posix.watchers;
 
 import eventcore.driver;
 import eventcore.drivers.posix.driver;
+import eventcore.internal.utils : nogc_assert;
 
 
 final class InotifyEventDriverWatchers(Events : EventDriverEvents) : EventDriverWatchers
@@ -64,7 +65,7 @@ final class InotifyEventDriverWatchers(Events : EventDriverEvents) : EventDriver
 	final override bool releaseRef(WatcherID descriptor)
 	{
 		FD fd = cast(FD)descriptor;
-		assert(m_loop.m_fds[fd].common.refCount > 0, "Releasing reference to unreferenced event FD.");
+		nogc_assert(m_loop.m_fds[fd].common.refCount > 0, "Releasing reference to unreferenced event FD.");
 		if (--m_loop.m_fds[fd].common.refCount == 1) { // NOTE: 1 because setNotifyCallback increments the reference count
 			m_loop.unregisterFD(fd, EventMask.read);
 			m_loop.clearFD(fd);
@@ -281,10 +282,10 @@ final class PollEventDriverWatchers(Events : EventDriverEvents) : EventDriverWat
 
 	final override bool releaseRef(WatcherID descriptor)
 	{
-		assert(descriptor != WatcherID.invalid);
+		nogc_assert(descriptor != WatcherID.invalid, "Invalid directory watcher ID released");
 		auto evt = cast(EventID)descriptor;
 		auto pt = evt in m_pollers;
-		assert(pt !is null);
+		nogc_assert(pt !is null, "Directory watcher polling thread does not exist");
 		if (!m_events.releaseRef(evt)) {
 			pt.dispose();
 			m_pollers.remove(evt);

--- a/source/eventcore/drivers/timer.d
+++ b/source/eventcore/drivers/timer.d
@@ -5,6 +5,7 @@ module eventcore.drivers.timer;
 
 import eventcore.driver;
 import eventcore.internal.dlist;
+import eventcore.internal.utils : nogc_assert;
 
 
 final class LoopTimeoutTimerDriver : EventDriverTimers {
@@ -143,8 +144,8 @@ final class LoopTimeoutTimerDriver : EventDriverTimers {
 
 	final override bool releaseRef(TimerID descriptor)
 	{
-		assert(descriptor != TimerID.init, "Invalid timer ID.");
-		assert(descriptor in m_timers, "Unknown timer ID.");
+		nogc_assert(descriptor != TimerID.init, "Invalid timer ID.");
+		nogc_assert((descriptor in m_timers) !is null, "Unknown timer ID.");
 		if (descriptor !in m_timers) return true;
 
 		auto tm = m_timers[descriptor];

--- a/source/eventcore/drivers/winapi/core.d
+++ b/source/eventcore/drivers/winapi/core.d
@@ -5,6 +5,7 @@ version (Windows):
 import eventcore.driver;
 import eventcore.drivers.timer;
 import eventcore.internal.consumablequeue;
+import eventcore.internal.utils : nogc_assert;
 import eventcore.internal.win32;
 import core.time : Duration;
 import taggedalgebraic;
@@ -180,7 +181,7 @@ final class WinAPIEventDriverCore : EventDriverCore {
 
 	package void freeSlot(HANDLE h)
 	{
-		assert(h in m_handles, "Handle not in use - cannot free.");
+		nogc_assert((h in m_handles) !is null, "Handle not in use - cannot free.");
 		m_handles.remove(h);
 	}
 }
@@ -214,7 +215,7 @@ private struct HandleSlot {
 
 	bool releaseRef(scope void delegate() @safe nothrow on_free)
 	{
-		assert(refCount > 0);
+		nogc_assert(refCount > 0, "Releasing unreferenced slot.");
 		if (--refCount == 0) {
 			on_free();
 			return false;

--- a/source/eventcore/drivers/winapi/events.d
+++ b/source/eventcore/drivers/winapi/events.d
@@ -6,6 +6,7 @@ import eventcore.driver;
 import eventcore.drivers.winapi.core;
 import eventcore.internal.win32;
 import eventcore.internal.consumablequeue;
+import eventcore.internal.utils : nogc_assert;
 
 
 final class WinAPIEventDriverEvents : EventDriverEvents {
@@ -108,7 +109,7 @@ final class WinAPIEventDriverEvents : EventDriverEvents {
 	override bool releaseRef(EventID descriptor)
 	{
 		auto pe = descriptor in m_events;
-		assert(pe.refCount > 0);
+		nogc_assert(pe.refCount > 0, "Releasing unreference event.");
 		if (--pe.refCount == 0) {
 			// make sure to not leak any waiter references for pending waits
 			foreach (i; 0 .. pe.waiters.length)

--- a/source/eventcore/drivers/winapi/sockets.d
+++ b/source/eventcore/drivers/winapi/sockets.d
@@ -5,7 +5,7 @@ version (Windows):
 import eventcore.driver;
 import eventcore.drivers.winapi.core;
 import eventcore.internal.win32;
-import eventcore.internal.utils : AlgebraicChoppedVector, print;
+import eventcore.internal.utils : AlgebraicChoppedVector, print, nogc_assert;
 import std.socket : Address;
 
 private enum WM_USER_SOCKET = WM_USER + 1;
@@ -697,7 +697,7 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 	override bool releaseRef(SocketFD fd)
 	{
 		import taggedalgebraic : hasType;
-		assert(m_sockets[fd].common.refCount > 0, "Releasing reference to unreferenced socket FD.");
+		nogc_assert(m_sockets[fd].common.refCount > 0, "Releasing reference to unreferenced socket FD.");
 		if (--m_sockets[fd].common.refCount == 0) {
 			final switch (m_sockets[fd].specific.kind) with (SocketVector.FieldType) {
 				case Kind.none: break;


### PR DESCRIPTION
Unfortunately the built-in assert GC allocates an exception, which means that if called directly or indirectly form a finalizer, the assertion will not become visible and instead an InvalidMemoryOperationError is thrown.

This implements a custom nogc_assert() function that directly prints the assertion message and uses abort() to end the process.