### PR TITLE
Call the callback on connectStream socket creation failure.

### DIFF
--- a/source/eventcore/driver.d
+++ b/source/eventcore/driver.d
@@ -570,6 +570,7 @@ enum ConnectStatus {
 	refused,
 	timeout,
 	bindFailure,
+	socketCreateFailure,
 	unknownError
 }
 

--- a/source/eventcore/drivers/posix/sockets.d
+++ b/source/eventcore/drivers/posix/sockets.d
@@ -90,7 +90,10 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 		assert(on_connect !is null);
 
 		auto sockfd = createSocket(address.addressFamily, SOCK_STREAM);
-		if (sockfd == -1) return StreamSocketFD.invalid;
+		if (sockfd == -1) {
+			on_connect(StreamSocketFD.invalid, ConnectStatus.socketCreateFailure);
+			return StreamSocketFD.invalid;
+		}
 
 		auto sock = cast(StreamSocketFD)sockfd;
 

--- a/source/eventcore/drivers/winapi/sockets.d
+++ b/source/eventcore/drivers/winapi/sockets.d
@@ -41,8 +41,10 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 		assert(m_tid == GetCurrentThreadId());
 
 		auto fd = WSASocketW(peer_address.addressFamily, SOCK_STREAM, IPPROTO_TCP, null, 0, WSA_FLAG_OVERLAPPED);
-		if (fd == INVALID_SOCKET)
+		if (fd == INVALID_SOCKET) {
+			on_connect(StreamSocketFD.invalid, ConnectStatus.socketCreateFailure);
 			return StreamSocketFD.invalid;
+		}
 
 		void invalidateSocket() @nogc @trusted nothrow { closesocket(fd); fd = INVALID_SOCKET; }
 


### PR DESCRIPTION
The callback must *always* be called at some point, because the generic async->sync logic in vibe-core otherwise has no way to know whether to expect a callback or not.