### PR TITLE
Implement runInOwnerThread

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,10 +41,6 @@ environment:
     DVersion: 2.072.2
     arch: x64
     config: winapi
-  - DC: dmd
-    DVersion: 2.071.1
-    arch: x86
-    config: winapi-optlink
   - DC: ldc
     DVersion: 1.7.0
     arch: x64

--- a/source/eventcore/drivers/winapi/driver.d
+++ b/source/eventcore/drivers/winapi/driver.d
@@ -60,15 +60,16 @@ final class WinAPIEventDriver : EventDriver {
 
 @safe: /*@nogc:*/ nothrow:
 
-	override @property WinAPIEventDriverCore core() { return m_core; }
-	override @property WinAPIEventDriverFiles files() { return m_files; }
-	override @property WinAPIEventDriverSockets sockets() { return m_sockets; }
-	override @property WinAPIEventDriverDNS dns() { return m_dns; }
-	override @property LoopTimeoutTimerDriver timers() { return m_timers; }
-	override @property WinAPIEventDriverEvents events() { return m_events; }
-	override @property shared(WinAPIEventDriverEvents) events() shared { return m_events; }
-	override @property WinAPIEventDriverSignals signals() { return m_signals; }
-	override @property WinAPIEventDriverWatchers watchers() { return m_watchers; }
+	override @property inout(WinAPIEventDriverCore) core() inout { return m_core; }
+	override @property shared(inout(WinAPIEventDriverCore)) core() inout shared { return m_core; }
+	override @property inout(WinAPIEventDriverFiles) files() inout { return m_files; }
+	override @property inout(WinAPIEventDriverSockets) sockets() inout { return m_sockets; }
+	override @property inout(WinAPIEventDriverDNS) dns() inout { return m_dns; }
+	override @property inout(LoopTimeoutTimerDriver) timers() inout { return m_timers; }
+	override @property inout(WinAPIEventDriverEvents) events() inout { return m_events; }
+	override @property shared(inout(WinAPIEventDriverEvents)) events() inout shared { return m_events; }
+	override @property inout(WinAPIEventDriverSignals) signals() inout { return m_signals; }
+	override @property inout(WinAPIEventDriverWatchers) watchers() inout { return m_watchers; }
 
 	override void dispose()
 	{

--- a/tests/0-runinownerthread.d
+++ b/tests/0-runinownerthread.d
@@ -1,0 +1,37 @@
+/++ dub.sdl:
+	name "test"
+	dependency "eventcore" path=".."
++/
+module test;
+
+import eventcore.core;
+import core.thread;
+import std.stdint;
+
+intptr_t s_id; // thread-local
+
+void main()
+{
+	auto ed = cast(shared)eventDriver;
+
+	auto thr = new Thread({ threadFunc(ed); });
+	thr.start();
+
+	// keep the event loop running for one second
+	auto tm = eventDriver.timers.create();
+	eventDriver.timers.set(tm, 1.seconds, 0.seconds);
+
+	ExitReason er;
+	do er = eventDriver.core.processEvents(Duration.max);
+	while (er == ExitReason.idle);
+	assert(er == ExitReason.outOfWaiters);
+
+	assert(s_id == 42);
+}
+
+void threadFunc(shared(NativeEventDriver) drv)
+{
+	drv.core.runInOwnerThread((id) {
+		s_id = id;
+	}, 42);
+}


### PR DESCRIPTION
Allows to execute a callback in the thread that owns a given event driver.

This is required to work around threading issues due to the GC implementation that may call destructors in any thread.