### PR TITLE
Get the listen backlog size from net.core.somaxconn on Linux

### DIFF
--- a/source/eventcore/drivers/posix/sockets.d
+++ b/source/eventcore/drivers/posix/sockets.d
@@ -955,14 +955,15 @@ private int getSocketError()
 	version (Windows) return WSAGetLastError();
 	else return errno;
 }
+
 private int getBacklogSize()
 @trusted @nogc nothrow {
 	int backlog = 128;
-	version(linux)
+	version (linux)
 	{
 		import core.stdc.stdio : fclose, fopen, fscanf;
 		auto somaxconn = fopen("/proc/sys/net/core/somaxconn", "re");
-		if(somaxconn)
+		if (somaxconn)
 		{
 			int tmp;
 			if (fscanf(somaxconn, "%d", &tmp) == 1)

--- a/source/eventcore/drivers/posix/sockets.d
+++ b/source/eventcore/drivers/posix/sockets.d
@@ -960,13 +960,14 @@ private int getBacklogSize()
 	int backlog = 128;
 	version(linux)
 	{
-		import core.stdc.stdio : fopen, fscanf;
+		import core.stdc.stdio : fclose, fopen, fscanf;
 		auto somaxconn = fopen("/proc/sys/net/core/somaxconn", "re");
 		if(somaxconn)
 		{
 			int tmp;
 			if (fscanf(somaxconn, "%d", &tmp) == 1)
 				backlog = tmp;
+			fclose(somaxconn);
 		}
 	}
 	return backlog;


### PR DESCRIPTION
From listen(2) man page:

> If the backlog argument is greater than the value in /proc/sys/net/core/somaxconn, then it is silently truncated to that value; the default value in this file is 128.  In kernels before 2.4.25, this limit was a hard coded value, SOMAXCONN, with the value 128.