### PR TITLE
fix Keepalive on Linux, expose keepalive options, TCP_USER_TIMEOUT for linux.

### DIFF
--- a/source/eventcore/driver.d
+++ b/source/eventcore/driver.d
@@ -215,6 +215,19 @@ interface EventDriverSockets {
 	/// Sets to `SO_KEEPALIVE` socket option on a socket.
 	void setKeepAlive(StreamSocketFD socket, bool enable);
 
+	/** Enables keepalive for the TCP socket and sets additional parameters.
+		Silently ignores unsupported systems.
+
+		Params:
+			socket = Socket file descriptor to set options on.
+			idle = The time the connection needs to remain idle
+				before TCP starts sending keepalive probes.
+			interval = The time between individual keepalive probes.
+			probeCount = The maximum number of keepalive probes TCP should send
+				before dropping the connection. Has no effect on Windows.
+	*/
+	void setKeepAliveParams(StreamSocketFD socket, Duration idle, Duration interval, int probeCount = 5);
+
 	/** Reads data from a stream socket.
 
 		Note that only a single read operation is allowed at once. The caller

--- a/source/eventcore/driver.d
+++ b/source/eventcore/driver.d
@@ -228,6 +228,9 @@ interface EventDriverSockets {
 	*/
 	void setKeepAliveParams(StreamSocketFD socket, Duration idle, Duration interval, int probeCount = 5);
 
+	/// Sets `TCP_USER_TIMEOUT` socket option (linux only). https://tools.ietf.org/html/rfc5482
+	void setUserTimeout(StreamSocketFD socket, Duration timeout);
+
 	/** Reads data from a stream socket.
 
 		Note that only a single read operation is allowed at once. The caller

--- a/source/eventcore/driver.d
+++ b/source/eventcore/driver.d
@@ -216,7 +216,7 @@ interface EventDriverSockets {
 	void setKeepAlive(StreamSocketFD socket, bool enable);
 
 	/** Enables keepalive for the TCP socket and sets additional parameters.
-		Silently ignores unsupported systems.
+		Silently ignores unsupported systems (anything but Windows and Linux).
 
 		Params:
 			socket = Socket file descriptor to set options on.

--- a/source/eventcore/drivers/posix/sockets.d
+++ b/source/eventcore/drivers/posix/sockets.d
@@ -50,10 +50,12 @@ version (linux) {
 
 	// Linux-specific TCP options
 	// https://github.com/torvalds/linux/blob/master/include/uapi/linux/tcp.h#L95
+	// Some day we should siply import core.sys.linux.netinet.tcp;
 	enum SOL_TCP = 6;
 	enum TCP_KEEPIDLE = 4;
 	enum TCP_KEEPINTVL = 5;
 	enum TCP_KEEPCNT = 6;
+	enum TCP_USER_TIMEOUT = 18;
 }
 version(OSX) {
 	static if (__VERSION__ < 2077) {
@@ -303,22 +305,54 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 		() @trusted { setsockopt(cast(sock_t)socket, IPPROTO_TCP, TCP_NODELAY, cast(char*)&opt, opt.sizeof); } ();
 	}
 
-	final override void setKeepAlive(StreamSocketFD socket, bool enable)
+	override void setKeepAlive(StreamSocketFD socket, bool enable) @trusted
 	{
-		ubyte opt = enable;
-		() @trusted { setsockopt(cast(sock_t)socket, SOL_SOCKET, SO_KEEPALIVE, cast(char*)&opt, opt.sizeof); } ();
+		int opt = enable;
+		int err = setsockopt(cast(sock_t)socket, SOL_SOCKET, SO_KEEPALIVE, &opt, int.sizeof);
+		if (err != 0)
+		{
+			print("sock error %s", getSocketError);
+			assert(0, "unable to set SO_KEEPALIVE option");
+		}
 	}
 
 	override void setKeepAliveParams(StreamSocketFD socket, Duration idle, Duration interval, int probeCount) @trusted
 	{
 		version (linux) {
-			ubyte opt = 1;
-			setsockopt(cast(sock_t)socket, SOL_SOCKET, SO_KEEPALIVE, cast(char*)&opt, opt.sizeof);
+			setKeepAlive(socket, true);
 			int int_opt = cast(int) idle.total!"seconds"();
-			setsockopt(cast(sock_t)socket, SOL_TCP, TCP_KEEPIDLE, &int_opt, int.sizeof);
+			int err = setsockopt(cast(sock_t)socket, SOL_TCP, TCP_KEEPIDLE, &int_opt, int.sizeof);
+			if (err != 0)
+			{
+				print("sock error %s", getSocketError);
+				assert(0, "unable to set TCP_KEEPIDLE option");
+			}
 			int_opt = cast(int) interval.total!"seconds"();
-			setsockopt(cast(sock_t)socket, SOL_TCP, TCP_KEEPINTVL, &int_opt, int.sizeof);
-			setsockopt(cast(sock_t)socket, SOL_TCP, TCP_KEEPCNT, &probeCount, int.sizeof);
+			err = setsockopt(cast(sock_t)socket, SOL_TCP, TCP_KEEPINTVL, &int_opt, int.sizeof);
+			if (err != 0)
+			{
+				print("sock error %s", getSocketError);
+				assert(0, "unable to set TCP_KEEPINTVL option");
+			}
+			err = setsockopt(cast(sock_t)socket, SOL_TCP, TCP_KEEPCNT, &probeCount, int.sizeof);
+			if (err != 0)
+			{
+				print("sock error %s", getSocketError);
+				assert(0, "unable to set TCP_KEEPCNT option");
+			}
+		}
+	}
+
+	override void setUserTimeout(StreamSocketFD socket, Duration timeout) @trusted
+	{
+		version (linux) {
+			uint tmsecs = cast(uint) timeout.total!"msecs";
+			int err = setsockopt(cast(sock_t)socket, SOL_TCP, TCP_USER_TIMEOUT, &tmsecs, uint.sizeof);
+			if (err != 0)
+			{
+				print("sock error %s", getSocketError);
+				assert(0, "unable to set TCP_USER_TIMEOUT option");
+			}
 		}
 	}
 

--- a/source/eventcore/drivers/winapi/sockets.d
+++ b/source/eventcore/drivers/winapi/sockets.d
@@ -221,6 +221,18 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 		setsockopt(socket, SOL_SOCKET, SO_KEEPALIVE, &eni, eni.sizeof);
 	}
 
+	override void setKeepAliveParams(StreamSocketFD socket, Duration idle, Duration interval, int probeCount) @trusted
+	{
+		if (idle < Duration.zero)
+			assert(0, "negative idle duration");
+		if (interval < Duration.zero)
+			assert(0, "negative interval duration");
+		tcp_keepalive opts = tcp_keepalive(1, cast(ulong) idle.total!"msecs"(),
+			cast(ulong) interval.total!"msecs");
+		int result = WSAIoctl(socket, SIO_KEEPALIVE_VALS, &opts, tcp_keepalive.sizeof, null, 0, null, null);
+		assert(result == 0);
+	}
+
 	override void read(StreamSocketFD socket, ubyte[] buffer, IOMode mode, IOCallback on_read_finish)
 	{
 		auto slot = () @trusted { return &m_sockets[socket].streamSocket(); } ();

--- a/source/eventcore/drivers/winapi/sockets.d
+++ b/source/eventcore/drivers/winapi/sockets.d
@@ -225,15 +225,12 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 
 	override void setKeepAliveParams(StreamSocketFD socket, Duration idle, Duration interval, int probeCount) @trusted
 	{
-		tcp_keepalive opts = tcp_keepalive(1, cast(ulong) idle.total!"msecs"(),
-			cast(ulong) interval.total!"msecs");
-		int result = WSAIoctl(socket, SIO_KEEPALIVE_VALS, &opts, cast(uint) tcp_keepalive.sizeof,
+		tcp_keepalive opts = tcp_keepalive(1, cast(c_ulong) idle.total!"msecs"(),
+			cast(c_ulong) interval.total!"msecs");
+		int result = WSAIoctl(socket, SIO_KEEPALIVE_VALS, &opts, cast(DWORD) tcp_keepalive.sizeof,
 			null, 0, null, null, null);
 		if (result != 0)
-		{
-			print("WSAIoctl SIO_KEEPALIVE_VALS returned %d", result);
-			assert(0, "unable to set TCP keepAlive parameters");
-		}
+			print("WSAIoctl error on SIO_KEEPALIVE_VALS: %d", WSAGetLastError());
 	}
 
 	override void setUserTimeout(StreamSocketFD socket, Duration timeout) {}

--- a/source/eventcore/drivers/winapi/sockets.d
+++ b/source/eventcore/drivers/winapi/sockets.d
@@ -8,6 +8,8 @@ import eventcore.internal.win32;
 import eventcore.internal.utils : AlgebraicChoppedVector, print, nogc_assert;
 import std.socket : Address;
 
+import core.time: Duration;
+
 private enum WM_USER_SOCKET = WM_USER + 1;
 
 
@@ -225,7 +227,8 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 	{
 		tcp_keepalive opts = tcp_keepalive(1, cast(ulong) idle.total!"msecs"(),
 			cast(ulong) interval.total!"msecs");
-		int result = WSAIoctl(socket, SIO_KEEPALIVE_VALS, &opts, tcp_keepalive.sizeof, null, 0, null, null);
+		int result = WSAIoctl(socket, SIO_KEEPALIVE_VALS, &opts, cast(uint) tcp_keepalive.sizeof,
+			null, 0, null, null, null);
 		if (result != 0)
 		{
 			print("WSAIoctl SIO_KEEPALIVE_VALS returned %d", result);

--- a/source/eventcore/internal/win32.d
+++ b/source/eventcore/internal/win32.d
@@ -112,18 +112,18 @@ struct tcp_keepalive {
 };
 
 // https://gist.github.com/piscisaureus/906386#file-winsock2-h-L1099
-enum : ulong {
+enum : DWORD {
 	IOC_VENDOR = 0x18000000,
 	IOC_OUT = 0x40000000,
 	IOC_IN = 0x80000000
 }
 
-ulong _WSAIOW(ulong x, ulong y) pure @safe
+DWORD _WSAIOW(DWORD x, DWORD y) pure @safe
 {
 	return IOC_IN | x | y;
 }
 
-enum : ulong {
+enum : DWORD {
 	SIO_KEEPALIVE_VALS = _WSAIOW(IOC_VENDOR, 4)
 }
 

--- a/source/eventcore/internal/win32.d
+++ b/source/eventcore/internal/win32.d
@@ -104,6 +104,29 @@ struct ADDRINFOW {
 	ADDRINFOW* ai_next;
 }
 
+// https://msdn.microsoft.com/en-us/library/windows/desktop/dd877220(v=vs.85).aspx
+struct tcp_keepalive {
+	ulong onoff;
+	ulong keepalivetime;
+	ulong keepaliveinterval;
+};
+
+// https://gist.github.com/piscisaureus/906386#file-winsock2-h-L1099
+enum : ulong {
+	IOC_VENDOR = 0x18000000,
+	IOC_OUT = 0x40000000,
+	IOC_IN = 0x80000000
+}
+
+ulong _WSAIOW(ulong x, ulong y) pure @safe
+{
+	return IOC_IN | x | y;
+}
+
+enum : ulong {
+	SIO_KEEPALIVE_VALS = _WSAIOW(IOC_VENDOR, 4)
+}
+
 struct WSAPROTOCOL_INFO {
 	DWORD            dwServiceFlags1;
 	DWORD            dwServiceFlags2;
@@ -154,6 +177,7 @@ void FreeAddrInfoExW(ADDRINFOEXW* pAddrInfo);
 void freeaddrinfo(ADDRINFOA* ai);
 BOOL TransmitFile(SOCKET hSocket, HANDLE hFile, DWORD nNumberOfBytesToWrite, DWORD nNumberOfBytesPerSend, OVERLAPPED* lpOverlapped, LPTRANSMIT_FILE_BUFFERS lpTransmitBuffers, DWORD dwFlags);
 BOOL CancelIoEx(HANDLE hFile, LPOVERLAPPED lpOverlapped);
+int WSAIoctl(SOCKET s, DWORD dwIoControlCode, void* lpvInBuffer, DWORD cbInBuffer, void* lpvOutBuffer, DWORD cbOutBuffer, DWORD* lpcbBytesReturned, in WSAOVERLAPPEDX* lpOverlapped, LPWSAOVERLAPPED_COMPLETION_ROUTINEX lpCompletionRoutine);
 
 /*struct WSAOVERLAPPEDX {
 	ULONG_PTR Internal;

--- a/source/eventcore/internal/win32.d
+++ b/source/eventcore/internal/win32.d
@@ -4,6 +4,7 @@ version(Windows):
 
 public import core.sys.windows.windows;
 public import core.sys.windows.winsock2;
+public import core.stdc.config: c_ulong;
 
 extern(System) nothrow:
 
@@ -106,9 +107,9 @@ struct ADDRINFOW {
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/dd877220(v=vs.85).aspx
 struct tcp_keepalive {
-	ulong onoff;
-	ulong keepalivetime;
-	ulong keepaliveinterval;
+	c_ulong onoff;
+	c_ulong keepalivetime;
+	c_ulong keepaliveinterval;
 };
 
 // https://gist.github.com/piscisaureus/906386#file-winsock2-h-L1099

--- a/source/eventcore/socket.d
+++ b/source/eventcore/socket.d
@@ -2,6 +2,7 @@ module eventcore.socket;
 
 import eventcore.core : eventDriver;
 import eventcore.driver;
+import core.time: Duration;
 import std.exception : enforce;
 import std.socket : Address;
 
@@ -49,6 +50,11 @@ struct StreamSocket {
 
 	@property ConnectionState state() { return eventDriver.sockets.getConnectionState(m_fd); }
 	@property void tcpNoDelay(bool enable) { eventDriver.sockets.setTCPNoDelay(m_fd, enable); }
+	void setKeepAlive(bool enable) { eventDriver.sockets.setKeepAlive(m_fd, enable); }
+	void setKeepAliveParams(Duration idle, Duration interval, int probeCount = 5) {
+		eventDriver.sockets.setKeepAliveParams(m_fd, idle, interval, probeCount);
+	}
+	void setUserTimeout(Duration timeout) { eventDriver.sockets.setUserTimeout(m_fd, timeout); }
 }
 
 void read(alias callback)(ref StreamSocket socket, ubyte[] buffer, IOMode mode)

--- a/tests/0-tcp-readwait.d
+++ b/tests/0-tcp-readwait.d
@@ -19,7 +19,7 @@ void main()
 		writeln("This doesn't work on macOS. Skipping this test until it is determined that this special case should stay supported.");
 		return;
 	} else {
-	
+
 	static ubyte[] pack1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
 	auto baddr 	= new InternetAddress(0x7F000001, 40002);

--- a/tests/0-tcp.d
+++ b/tests/0-tcp.d
@@ -8,7 +8,7 @@ import eventcore.core;
 import eventcore.socket;
 import eventcore.internal.utils : print;
 import std.socket : InternetAddress;
-import core.time : Duration, msecs;
+import core.time : Duration, msecs, seconds;
 
 ubyte[256] s_rbuf;
 bool s_done;
@@ -69,6 +69,10 @@ void main()
 		client = sock;
 		assert(status == ConnectStatus.connected);
 		assert(sock.state == ConnectionState.connected);
+		print("Setting keepalive and timeout options");
+		client.setKeepAlive(true);
+		client.setKeepAliveParams(10.seconds, 10.seconds, 4);
+		client.setUserTimeout(5.seconds);
 		print("Initial write");
 		client.write!((wstatus, bytes) {
 			print("Initial write done");


### PR DESCRIPTION
1. setKeepAlive was broken on linux bacause of wrong parameter type. It was hidden behind the absence of error checking in that call.
2. new method setKeepAliveParams for EventDriverSockets, wich gives more control over keepalive. #75 . Tested under Linux.
3. setUserTimeout socket option for linux exposed. https://tools.ietf.org/html/rfc5482

Windows setKeepAliveParams compiles, but I did not test it.