### PR TITLE
Fix initialization behavior when being loaded as a shared library.

### DIFF
--- a/source/eventcore/core.d
+++ b/source/eventcore/core.d
@@ -27,24 +27,35 @@ else alias NativeEventDriver = EventDriver;
 static if (!is(NativeEventDriver == EventDriver)) {
 	static this()
 	{
-		if (!s_driver) s_driver = new NativeEventDriver;
+		if (!s_isMainThread) {
+			if (!s_initCount++) {
+				assert(s_driver is null);
+				s_driver = new NativeEventDriver;
+			}
+		}
 	}
 
 	static ~this()
 	{
-		if (!s_isMainThread)
-			s_driver.dispose();
+		if (!s_isMainThread) {
+			if (!--s_initCount)
+				s_driver.dispose();
+		}
 	}
 
 	shared static this()
 	{
-		s_driver = new NativeEventDriver;
-		s_isMainThread = true;
+		if (!s_initCount++) {
+			s_driver = new NativeEventDriver;
+			s_isMainThread = true;
+		}
 	}
 
 	shared static ~this()
 	{
-		s_driver.dispose();
+		if (!--s_initCount) {
+			s_driver.dispose();
+		}
 	}
 } else {
 	void setupEventDriver(EventDriver driver)
@@ -58,4 +69,7 @@ static if (!is(NativeEventDriver == EventDriver)) {
 private {
 	NativeEventDriver s_driver;
 	bool s_isMainThread;
+	// keeps track of nested DRuntime initializations that happen when
+	// (un)loading shared libaries.
+	int s_initCount = 0;
 }


### PR DESCRIPTION
When loading a shared library where both, the host and the library, use eventcore, the static constructors/destructors will be called multiple times.