### PR TITLE
Lazy driver initialization

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -8,7 +8,7 @@ targetType "library"
 libs "anl" "resolv" platform="linux"
 libs "ws2_32" "user32" platform="windows-dmd"
 
-dependency "taggedalgebraic" version="~>0.10.4"
+dependency "taggedalgebraic" version="~>0.10.12"
 
 configuration "epoll" {
 	platforms "linux"

--- a/source/eventcore/drivers/posix/dns.d
+++ b/source/eventcore/drivers/posix/dns.d
@@ -43,7 +43,7 @@ final class EventDriverDNS_GAI(Events : EventDriverEvents, Signals : EventDriver
 	}
 
 	this(Events events, Signals signals)
-	{
+	@nogc {
 		m_events = events;
 		setupEvent();
 	}
@@ -139,7 +139,7 @@ final class EventDriverDNS_GAI(Events : EventDriverEvents, Signals : EventDriver
 	}
 
 	private void setupEvent()
-	{
+	@nogc {
 		if (m_event == EventID.invalid) {
 			m_event = m_events.createInternal();
 			m_events.wait(m_event, &onDNSSignal);

--- a/source/eventcore/drivers/posix/driver.d
+++ b/source/eventcore/drivers/posix/driver.d
@@ -95,7 +95,6 @@ final class PosixEventDriver(Loop : PosixEventLoop) : EventDriver {
 		m_dns.dispose();
 		m_core.dispose();
 		m_loop.dispose();
-		m_loop = null;
 
 		try () @trusted {
 				freeT(m_watchers);

--- a/source/eventcore/drivers/posix/epoll.d
+++ b/source/eventcore/drivers/posix/epoll.d
@@ -5,7 +5,7 @@
 	numbers of concurrently open sockets.
 */
 module eventcore.drivers.posix.epoll;
-@safe: /*@nogc:*/ nothrow:
+@safe @nogc nothrow:
 
 version (linux):
 
@@ -22,17 +22,16 @@ static if (!is(typeof(SOCK_CLOEXEC)))
 	enum SOCK_CLOEXEC = 0x80000;
 
 final class EpollEventLoop : PosixEventLoop {
-@safe: nothrow:
+@safe nothrow:
 
 	private {
 		int m_epoll;
-		epoll_event[] m_events;
+		epoll_event[100] m_events;
 	}
 
 	this()
-	{
+	@nogc {
 		m_epoll = () @trusted { return epoll_create1(SOCK_CLOEXEC); } ();
-		m_events.length = 100;
 	}
 
 	override bool doProcessEvents(Duration timeout)
@@ -60,7 +59,7 @@ final class EpollEventLoop : PosixEventLoop {
 	}
 
 	override void dispose()
-	{
+	@nogc {
 		import core.sys.posix.unistd : close;
 		close(m_epoll);
 	}

--- a/source/eventcore/drivers/posix/signals.d
+++ b/source/eventcore/drivers/posix/signals.d
@@ -17,7 +17,7 @@ final class SignalFDEventDriverSignals(Loop : PosixEventLoop) : EventDriverSigna
 
 	private Loop m_loop;
 
-	this(Loop loop) { m_loop = loop; }
+	this(Loop loop) @nogc { m_loop = loop; }
 
 	override SignalListenID listen(int sig, SignalCallback on_signal)
 	{

--- a/source/eventcore/drivers/posix/watchers.d
+++ b/source/eventcore/drivers/posix/watchers.d
@@ -245,7 +245,7 @@ final class PollEventDriverWatchers(Events : EventDriverEvents) : EventDriverWat
 	}
 
 	this(Events events)
-	{
+	@nogc {
 		m_events = events;
 	}
 

--- a/source/eventcore/drivers/threadedfile.d
+++ b/source/eventcore/drivers/threadedfile.d
@@ -421,10 +421,10 @@ private struct StaticTaskPool {
 
 		if (!m_refCount++) {
 			try {
-				m_pool = new TaskPool(4);
+				m_pool = mallocT!TaskPool(4);
 				m_pool.isDaemon = true;
 			} catch (Exception e) {
-				assert(false, "Failed to create file thread pool: "~e.msg);
+				assert(false, e.msg);
 			}
 		}
 
@@ -447,8 +447,10 @@ private struct StaticTaskPool {
 
 		if (fin_pool) {
 			log("finishing thread pool");
-			try fin_pool.finish();
-			catch (Exception e) {
+			try {
+				fin_pool.finish(true);
+				freeT(fin_pool);
+			} catch (Exception e) {
 				//log("Failed to shut down file I/O thread pool.");
 			}
 		}

--- a/source/eventcore/drivers/winapi/events.d
+++ b/source/eventcore/drivers/winapi/events.d
@@ -6,7 +6,7 @@ import eventcore.driver;
 import eventcore.drivers.winapi.core;
 import eventcore.internal.win32;
 import eventcore.internal.consumablequeue;
-import eventcore.internal.utils : nogc_assert;
+import eventcore.internal.utils : mallocT, freeT, nogc_assert;
 
 
 final class WinAPIEventDriverEvents : EventDriverEvents {
@@ -31,10 +31,10 @@ final class WinAPIEventDriverEvents : EventDriverEvents {
 	}
 
 	this(WinAPIEventDriverCore core)
-	{
+	@nogc {
 		m_core = core;
 		m_event = () @trusted { return CreateEvent(null, false, false, null); } ();
-		m_pending = new ConsumableQueue!Trigger; // FIXME: avoid GC allocation
+		m_pending = mallocT!(ConsumableQueue!Trigger); // FIXME: avoid GC allocation
 		InitializeCriticalSection(&m_mutex);
 		m_core.registerEvent(m_event, &triggerPending);
 	}
@@ -42,7 +42,7 @@ final class WinAPIEventDriverEvents : EventDriverEvents {
 	void dispose()
 	@trusted {
 		scope (failure) assert(false);
-		destroy(m_pending);
+		freeT(m_pending);
 	}
 
 	override EventID create()

--- a/source/eventcore/drivers/winapi/files.d
+++ b/source/eventcore/drivers/winapi/files.d
@@ -17,7 +17,7 @@ final class WinAPIEventDriverFiles : EventDriverFiles {
 	}
 
 	this(WinAPIEventDriverCore core)
-	{
+	@nogc {
 		m_core = core;
 	}
 

--- a/source/eventcore/drivers/winapi/sockets.d
+++ b/source/eventcore/drivers/winapi/sockets.d
@@ -25,7 +25,7 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 	}
 
 	this(WinAPIEventDriverCore core)
-	@trusted {
+	@trusted @nogc {
 		m_tid = GetCurrentThreadId();
 		m_core = core;
 
@@ -406,7 +406,7 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 	}
 
 	override void cancelRead(StreamSocketFD socket)
-	@trusted {
+	@trusted @nogc {
 		if (!m_sockets[socket].streamSocket.read.callback) return;
 		CancelIoEx(cast(HANDLE)cast(SOCKET)socket, cast(LPOVERLAPPED)&m_sockets[socket].streamSocket.read.overlapped);
 		m_sockets[socket].streamSocket.read.callback = null;
@@ -414,7 +414,7 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 	}
 
 	override void cancelWrite(StreamSocketFD socket)
-	@trusted {
+	@trusted @nogc {
 		if (!m_sockets[socket].streamSocket.write.callback) return;
 		CancelIoEx(cast(HANDLE)cast(SOCKET)socket, cast(LPOVERLAPPED)&m_sockets[socket].streamSocket.write.overlapped);
 		m_sockets[socket].streamSocket.write.callback = null;
@@ -549,7 +549,7 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 	}
 
 	override void cancelReceive(DatagramSocketFD socket)
-	@trusted {
+	@trusted @nogc {
 		if (!m_sockets[socket].datagramSocket.read.callback) return;
 		CancelIoEx(cast(HANDLE)cast(SOCKET)socket, cast(LPOVERLAPPED)&m_sockets[socket].datagramSocket.read.overlapped);
 		m_sockets[socket].datagramSocket.read.callback = null;
@@ -643,7 +643,7 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 	}
 
 	override void cancelSend(DatagramSocketFD socket)
-	@trusted {
+	@trusted @nogc {
 		if (!m_sockets[socket].datagramSocket.write.callback) return;
 		CancelIoEx(cast(HANDLE)cast(SOCKET)socket, cast(LPOVERLAPPED)&m_sockets[socket].datagramSocket.write.overlapped);
 		m_sockets[socket].datagramSocket.write.callback = null;
@@ -719,7 +719,7 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 	}
 
 	override bool releaseRef(SocketFD fd)
-	{
+	@nogc {
 		import taggedalgebraic : hasType;
 		auto slot = () @trusted { return &m_sockets[fd]; } ();
 		nogc_assert(slot.common.refCount > 0, "Releasing reference to unreferenced socket FD.");
@@ -787,7 +787,7 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 	}
 
 	private void* rawUserDataImpl(FD descriptor, size_t size, DataInitializer initialize, DataInitializer destroy)
-	@system {
+	@system @nogc {
 		SocketSlot* fds = &m_sockets[descriptor].common;
 		assert(fds.userDataDestructor is null || fds.userDataDestructor is destroy,
 			"Requesting user data with differing type (destructor).");
@@ -808,7 +808,7 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 	}
 
 	package void clearSocketSlot(FD fd)
-	{
+	@nogc {
 		auto slot = () @trusted { return &m_sockets[fd]; } ();
 		if (slot.common.userDataDestructor)
 			() @trusted { slot.common.userDataDestructor(slot.common.userData.ptr); } ();
@@ -889,8 +889,8 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 	}
 }
 
-void setupWindowClass() nothrow
-@trusted {
+void setupWindowClass()
+@trusted nothrow @nogc {
 	static __gshared registered = false;
 
 	if (registered) return;

--- a/source/eventcore/drivers/winapi/watchers.d
+++ b/source/eventcore/drivers/winapi/watchers.d
@@ -16,7 +16,7 @@ final class WinAPIEventDriverWatchers : EventDriverWatchers {
 	}
 
 	this(WinAPIEventDriverCore core)
-	{
+	@nogc {
 		m_core = core;
 	}
 

--- a/source/eventcore/internal/utils.d
+++ b/source/eventcore/internal/utils.d
@@ -39,6 +39,8 @@ void freeT(T)(ref T inst) @nogc
 {
 	import core.stdc.stdlib : free;
 
+	if (!inst) return;
+
 	noGCDestroy(inst);
 	static if (hasIndirections!T)
 		GC.removeRange(cast(void*)inst);
@@ -151,12 +153,13 @@ struct ChoppedVector(T, size_t CHUNK_SIZE = 16*64*1024/nextPOT(T.sizeof)) {
 	@nogc {
 		() @trusted {
 			foreach (i; 0 .. m_chunkCount) {
-				destroy(m_chunks[i]);
+				destroy(*m_chunks[i]);
 				static if (hasIndirections!T)
 					GC.removeRange(m_chunks[i]);
 				free(m_chunks[i]);
 			}
 			free(m_chunks.ptr);
+			m_chunks = null;
 		} ();
 		m_chunkCount = 0;
 		m_length = 0;


### PR DESCRIPTION
This switches the initialization from `static this` to lazy singleton-style. Since the `eventDriver` property is marked `@nogc`, this required making a lot of the code `@nogc`, too. As a side-effect, this brings the codebase a good step closer to being better-C compatible.

The main advantage of this change is that it avoids useless initialization and shutdown, as well as resource use for threads that don't use the library at all. There also have been some crashes in such threads (caused by a compiler bug), which gets side-stepped by this. 