### PR TITLE
Introduce TimerCallback2.

### DIFF
--- a/source/eventcore/driver.d
+++ b/source/eventcore/driver.d
@@ -564,7 +564,12 @@ interface EventDriverTimers {
 	void stop(TimerID timer);
 	bool isPending(TimerID timer);
 	bool isPeriodic(TimerID timer);
-	void wait(TimerID timer, TimerCallback callback);
+	final void wait(TimerID timer, TimerCallback callback) {
+		wait(timer, (tm, fired) {
+			if (fired) callback(tm);
+		});
+	}
+	void wait(TimerID timer, TimerCallback2 callback);
 	void cancelWait(TimerID timer);
 
 	/** Increments the reference count of the given resource.
@@ -668,6 +673,7 @@ alias FileIOCallback = void delegate(FileFD, IOStatus, size_t);
 alias EventCallback = void delegate(EventID);
 alias SignalCallback = void delegate(SignalListenID, SignalStatus, int);
 alias TimerCallback = void delegate(TimerID);
+alias TimerCallback2 = void delegate(TimerID, bool fired);
 alias FileChangesCallback = void delegate(WatcherID, in ref FileChange change);
 @system alias DataInitializer = void function(void*) @nogc;
 

--- a/tests/0-timer.d
+++ b/tests/0-timer.d
@@ -57,6 +57,21 @@ void main()
 
 	eventDriver.timers.set(tm, 1200.msecs, 0.msecs);
 
+	// test if stop() produces a callback with fire==false
+	bool got_event = false;
+	auto tm2 = eventDriver.timers.create();
+	eventDriver.timers.wait(tm2, (t, fired) { assert(!fired); got_event = true; });
+	eventDriver.timers.set(tm2, 100.msecs, 0.msecs);
+	eventDriver.timers.stop(tm2);
+	assert(got_event);
+
+
+	// test that cancelWait() does not produce a callback
+	eventDriver.timers.wait(tm2, (t, fired) { assert(false); });
+	eventDriver.timers.set(tm2, 100.msecs, 0.msecs);
+	eventDriver.timers.cancelWait(tm2);
+	eventDriver.timers.stop(tm2);
+
 	ExitReason er;
 	do er = eventDriver.core.processEvents(Duration.max);
 	while (er == ExitReason.idle);


### PR DESCRIPTION
This allows getting notified also if the timer has been stopped, so that it is guaranteed to be called, except if cancelWait is called.

Necessary for fixing vibe-d/vibe-core#86