### PR TITLE
Remove the default dependency to libanl

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -5,12 +5,20 @@ copyright "Copyright © 2016-2018 Sönke Ludwig"
 
 targetType "library"
 
-libs "anl" "resolv" platform="linux"
+libs "resolv" platform="linux"
 libs "ws2_32" "user32" platform="windows-dmd"
 
 dependency "taggedalgebraic" version="~>0.10.12"
 
 configuration "epoll" {
+	platforms "linux"
+	versions "EventcoreEpollDriver"
+}
+
+// getaddrinfo_a based DNS lookups
+configuration "epoll-gaia" {
+	libs "anl"
+	versions "EventcoreUseGAIA"
 	platforms "linux"
 	versions "EventcoreEpollDriver"
 }

--- a/source/eventcore/drivers/posix/dns.d
+++ b/source/eventcore/drivers/posix/dns.d
@@ -158,6 +158,7 @@ final class EventDriverDNS_GAIA(Events : EventDriverEvents, Signals : EventDrive
 			DNSLookupCallback callback;
 		}
 		ChoppedVector!Lookup m_lookups;
+		Events m_events;
 		Signals m_signals;
 		int m_dnsSignal;
 		SignalListenID m_sighandle;
@@ -167,6 +168,7 @@ final class EventDriverDNS_GAIA(Events : EventDriverEvents, Signals : EventDrive
 
 	this(Events events, Signals signals)
 	{
+		m_events = events;
 		m_signals = signals;
 		m_dnsSignal = () @trusted { return SIGRTMIN; } ();
 		m_sighandle = signals.listenInternal(m_dnsSignal, &onDNSSignal);
@@ -214,6 +216,8 @@ final class EventDriverDNS_GAIA(Events : EventDriverEvents, Signals : EventDrive
 	{
 		assert(status == SignalStatus.ok);
 		foreach (i, ref l; m_lookups) {
+			scope (failure) assert(false);
+
 			if (!l.callback) continue;
 			auto err = gai_error(&l.ctx);
 			if (err == EAI_INPROGRESS) continue;
@@ -242,6 +246,8 @@ final class EventDriverDNS_GAIA(Events : EventDriverEvents, Signals : EventDrive
 
 version (linux) extern(C) {
 	import core.sys.posix.signal : sigevent;
+
+	nothrow @nogc:
 
 	struct gaicb {
 		const(char)* ar_name;

--- a/source/eventcore/drivers/posix/driver.d
+++ b/source/eventcore/drivers/posix/driver.d
@@ -45,7 +45,7 @@ final class PosixEventDriver(Loop : PosixEventLoop) : EventDriver {
 		alias TimerDriver = LoopTimeoutTimerDriver;
 		alias SocketsDriver = PosixEventDriverSockets!Loop;
 		version (Windows) alias DNSDriver = EventDriverDNS_GHBN!(EventsDriver, SignalsDriver);
-		//version (linux) alias DNSDriver = EventDriverDNS_GAIA!(EventsDriver, SignalsDriver);
+		else version (EventcoreUseGAIA) alias DNSDriver = EventDriverDNS_GAIA!(EventsDriver, SignalsDriver);
 		else alias DNSDriver = EventDriverDNS_GAI!(EventsDriver, SignalsDriver);
 		alias FileDriver = ThreadedFileEventDriver!EventsDriver;
 		version (linux) alias WatcherDriver = InotifyEventDriverWatchers!EventsDriver;


### PR DESCRIPTION
The dependency wasn't used at all, but is now optionally used through the epoll-gaia configuration.

Fixes #78.