### PR TITLE
Use monotonic clock for timeout

### DIFF
--- a/source/eventcore/drivers/posix/watchers.d
+++ b/source/eventcore/drivers/posix/watchers.d
@@ -404,17 +404,16 @@ final class PollEventDriverWatchers(Events : EventDriverEvents) : EventDriverWat
 
 		private void run()
 		nothrow @trusted {
-			import core.time : msecs;
+			import core.time : MonoTime, msecs;
 			import std.algorithm.comparison : min;
-			import std.datetime : Clock, UTC;
 
 			try while (true) {
-				auto timeout = Clock.currTime(UTC()) + min(m_entryCount, 60000).msecs + 1000.msecs;
+				auto timeout = MonoTime.currTime() + min(m_entryCount, 60000).msecs + 1000.msecs;
 				while (true) {
 					try synchronized (m_changesMutex) {
 						if (m_changesEvent == EventID.invalid) return;
 					} catch (Exception e) assert(false, "Mutex lock failed: "~e.msg);
-					auto remaining = timeout - Clock.currTime(UTC());
+					auto remaining = timeout - MonoTime.currTime();
 					if (remaining <= 0.msecs) break;
 					sleep(min(1000.msecs, remaining));
 				}

--- a/tests/0-dirwatcher-rec.d
+++ b/tests/0-dirwatcher-rec.d
@@ -7,7 +7,7 @@ module test;
 import eventcore.core;
 import eventcore.internal.utils : print;
 import core.thread : Thread;
-import core.time : Duration, msecs;
+import core.time : Duration, MonoTime, msecs;
 import std.file : exists, remove, rename, rmdirRecurse, mkdir;
 import std.format : format;
 import std.functional : toDelegate;
@@ -80,9 +80,7 @@ void testCallback(WatcherID w, in ref FileChange ch)
 
 void expectChange(FileChange ch, bool expect_change)
 {
-	import std.datetime : Clock, UTC;
-
-	auto starttime = Clock.currTime(UTC());
+	auto starttime = MonoTime.currTime();
 	again: while (!pendingChanges.length) {
 		auto er = eventDriver.core.processEvents(10.msecs);
 		switch (er) {
@@ -95,7 +93,7 @@ void expectChange(FileChange ch, bool expect_change)
 				assert(!expect_change, "No watcher left, but expected change.");
 				return;
 		}
-		if (!pendingChanges.length && Clock.currTime(UTC()) - starttime >= 2000.msecs) {
+		if (!pendingChanges.length && MonoTime.currTime() - starttime >= 2000.msecs) {
 			assert(!expect_change, format("Got no change, expected %s.", ch));
 			return;
 		}

--- a/tests/0-timer.d
+++ b/tests/0-timer.d
@@ -5,17 +5,16 @@
 module test;
 
 import eventcore.core;
-import std.datetime : Clock, SysTime, UTC;
+import core.time : Duration, MonoTime, msecs;
 import std.stdio : writefln;
-import core.time : Duration, msecs;
 
-SysTime s_startTime;
+MonoTime s_startTime;
 int s_cnt = 0;
 bool s_done;
 
 void main()
 {
-	s_startTime = Clock.currTime(UTC());
+	s_startTime = MonoTime.currTime();
 
 	auto tm = eventDriver.timers.create();
 	eventDriver.timers.wait(tm, (tm) nothrow @safe {
@@ -23,7 +22,7 @@ void main()
 
 		{
 			scope (failure) assert(false);
-			dur = Clock.currTime(UTC()) - s_startTime;
+			dur = MonoTime.currTime() - s_startTime;
 		}
 
 		try {
@@ -37,7 +36,7 @@ void main()
 
 		void secondTier(TimerID timer) nothrow @safe {
 			try {
-				auto dur = Clock.currTime(UTC()) - s_startTime;
+				auto dur = MonoTime.currTime() - s_startTime;
 				s_cnt++;
 				assert(dur > 300.msecs * s_cnt, (dur - 300.msecs * s_cnt).toString());
 				assert(dur < 300.msecs * s_cnt + 100.msecs, (dur - 300.msecs * s_cnt).toString());

--- a/tests/issue-25-periodic-timers.d
+++ b/tests/issue-25-periodic-timers.d
@@ -5,17 +5,16 @@
 module test;
 
 import eventcore.core;
-import std.datetime : Clock, SysTime, UTC;
+import core.time : Duration, MonoTime, msecs;
 import std.stdio : writefln;
-import core.time : Duration, msecs;
 
-SysTime s_startTime;
+MonoTime s_startTime;
 int s_cnt = 0;
 bool s_done;
 
 void main()
 {
-	s_startTime = Clock.currTime(UTC());
+	s_startTime = MonoTime.currTime();
 
 	bool timer1fired = false;
 
@@ -24,7 +23,7 @@ void main()
 	eventDriver.timers.wait(tm, (tm) nothrow @safe {
 		try {
 			writefln("First timer");
-			auto dur = Clock.currTime(UTC()) - s_startTime;
+			auto dur = MonoTime.currTime() - s_startTime;
 
 			assert(dur >= 1200.msecs, (dur - 1200.msecs).toString());
 			assert(dur < 1300.msecs, (dur - 1200.msecs).toString());
@@ -43,7 +42,7 @@ void main()
 		try {
 			writefln("Second timer");
 
-			auto dur = Clock.currTime(UTC()) - s_startTime;
+			auto dur = MonoTime.currTime() - s_startTime;
 			s_cnt++;
 			assert(dur > 300.msecs * s_cnt, (dur - 300.msecs * s_cnt).toString());
 			assert(dur < 300.msecs * s_cnt + 100.msecs, (dur - 300.msecs * s_cnt).toString());


### PR DESCRIPTION
The system clock can be updated manually by the sys-admin or
automatically by NTP, so use monotonic clock instead.