### PR TITLE
Don't try to set the SO_REUSEPORT flag on Linux

### DIFF
--- a/source/eventcore/drivers/posix/sockets.d
+++ b/source/eventcore/drivers/posix/sockets.d
@@ -220,7 +220,7 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 		() @trusted {
 			int tmp_reuse = 1;
 			// FIXME: error handling!
-			if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &tmp_reuse, tmp_reuse.sizeof) != 0) {
+			if ((options & StreamListenOptions.reusePort) && setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &tmp_reuse, tmp_reuse.sizeof) != 0) {
 				invalidateSocket();
 				return;
 			}


### PR DESCRIPTION
On Linux this option was always set, regardless if the `StreamListenOptions` specifies it.

On some systems setting that option will result in a failure.