### PR TITLE
[PosixEventDriverEvents] Use Linux definitions from druntime

### DIFF
--- a/source/eventcore/drivers/posix/events.d
+++ b/source/eventcore/drivers/posix/events.d
@@ -8,7 +8,8 @@ import eventcore.internal.utils : nogc_assert, mallocT, freeT;
 
 
 version (linux) {
-	import core.sys.linux.sys.eventfd : eventfd, EFD_NONBLOCK, EFD_CLOEXEC;
+	nothrow @nogc extern (C) int eventfd(uint initval, int flags);
+    import core.sys.linux.sys.eventfd : EFD_NONBLOCK, EFD_CLOEXEC;
 }
 version (Posix) {
 	import core.sys.posix.unistd : close, read, write;

--- a/source/eventcore/drivers/posix/events.d
+++ b/source/eventcore/drivers/posix/events.d
@@ -8,9 +8,7 @@ import eventcore.internal.utils : nogc_assert, mallocT, freeT;
 
 
 version (linux) {
-	nothrow @nogc extern (C) int eventfd(uint initval, int flags);
-	enum EFD_NONBLOCK = 0x800;
-	enum EFD_CLOEXEC = 0x80000;
+	import core.sys.linux.sys.eventfd : eventfd, EFD_NONBLOCK, EFD_CLOEXEC;
 }
 version (Posix) {
 	import core.sys.posix.unistd : close, read, write;


### PR DESCRIPTION
This doesn't duplicate the definitions form `core.sys.linux.sys.eventfd` and will pickup any platform specifics for better portability.
Fixes https://github.com/vibe-d/eventcore/issues/102