### PR TITLE
Add `StreamListenOptions.reuseAddress`.

### DIFF
--- a/source/eventcore/driver.d
+++ b/source/eventcore/driver.d
@@ -713,8 +713,13 @@ enum ConnectionState {
 }
 
 enum StreamListenOptions {
-	defaults = 0,
+	none = 0,
+	/// Applies the `SO_REUSEPORT` flag
 	reusePort = 1<<0,
+	/// Avoids applying the `SO_REUSEADDR` flag
+	reuseAddress = 1<<1,
+	///
+	defaults = reuseAddress,
 }
 
 enum StreamSocketOption {

--- a/source/eventcore/drivers/posix/sockets.d
+++ b/source/eventcore/drivers/posix/sockets.d
@@ -221,9 +221,11 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 		() @trusted {
 			int tmp_reuse = 1;
 			// FIXME: error handling!
-			if ((options & StreamListenOptions.reusePort) && setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &tmp_reuse, tmp_reuse.sizeof) != 0) {
-				invalidateSocket();
-				return;
+			if (options & StreamListenOptions.reuseAddress) {
+				if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &tmp_reuse, tmp_reuse.sizeof) != 0) {
+					invalidateSocket();
+					return;
+				}
 			}
 			version (Windows) {} else {
 				if ((options & StreamListenOptions.reusePort) && setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT, &tmp_reuse, tmp_reuse.sizeof) != 0) {

--- a/source/eventcore/drivers/winapi/sockets.d
+++ b/source/eventcore/drivers/winapi/sockets.d
@@ -42,7 +42,7 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 	package bool checkForLeakedHandles()
 	{
 		if (m_socketCount == 0) return false;
-		print("Warning: Socket handles leaked at driver shutdown.");
+		print("Warning: %s socket handles leaked at driver shutdown.", m_socketCount);
 		return true;
 	}
 
@@ -155,10 +155,12 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 		void invalidateSocket() @nogc @trusted nothrow { closesocket(fd); fd = INVALID_SOCKET; }
 
 		() @trusted {
-			int tmp_reuse = 1;
-			if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &tmp_reuse, tmp_reuse.sizeof) != 0) {
-				invalidateSocket();
-				return;
+			if (options & StreamListenOptions.reuseAddress) {
+				int tmp_reuse = 1;
+				if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &tmp_reuse, tmp_reuse.sizeof) != 0) {
+					invalidateSocket();
+					return;
+				}
 			}
 
 			// FIXME: should SO_EXCLUSIVEADDRUSE be used of StreamListenOptions.reuseAddress isn't set?


### PR DESCRIPTION
Replaces the current combined behavior controlled by `reusePort`, introduced by #103.

Fixes https://github.com/vibe-d/vibe.d/issues/2280