### PR TITLE
Fix socket not being in a connected state after connectStream

### DIFF
--- a/source/eventcore/drivers/posix/sockets.d
+++ b/source/eventcore/drivers/posix/sockets.d
@@ -134,7 +134,7 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 
 		auto ret = () @trusted { return connect(cast(sock_t)sock, address.name, address.nameLen); } ();
 		if (ret == 0) {
-			m_loop.m_fds[sock].specific.state = ConnectionState.connected;
+			m_loop.m_fds[sock].streamSocket.state = ConnectionState.connected;
 			on_connect(sock, ConnectStatus.connected);
 		} else {
 			auto err = getSocketError();


### PR DESCRIPTION
Using vibe.d with a unix socket I discovered that after calling `connectTCP` a connection would still have `connected` be false a the socket fd was still in a `initialized` state.