### PR TITLE
Proposed fix for processes in multi-threaded environments

### DIFF
--- a/source/eventcore/drivers/posix/driver.d
+++ b/source/eventcore/drivers/posix/driver.d
@@ -79,7 +79,7 @@ final class PosixEventDriver(Loop : PosixEventLoop) : EventDriver {
 		m_signals = mallocT!SignalsDriver(m_loop);
 		m_timers = mallocT!TimerDriver;
 		m_pipes = mallocT!PipeDriver(m_loop);
-		m_processes = mallocT!ProcessDriver(m_loop, m_pipes);
+		m_processes = mallocT!ProcessDriver(m_loop, this);
 		m_core = mallocT!CoreDriver(m_loop, m_timers, m_events, m_processes);
 		m_dns = mallocT!DNSDriver(m_events, m_signals);
 		m_files = mallocT!FileDriver(m_events);

--- a/source/eventcore/drivers/posix/processes.d
+++ b/source/eventcore/drivers/posix/processes.d
@@ -295,7 +295,7 @@ final class SignalEventDriverProcesses(Loop : PosixEventLoop) : EventDriverProce
         // thread.
         if (() @trusted { return cast(void*)this == cast(void*)driver; } ()) {
             onLocalProcessExit(cast(intptr_t)pid);
-        } else {
+        } else if (driver) {
             auto sharedDriver = () @trusted { return cast(shared typeof(this))driver; } ();
 
             sharedDriver.m_driver.core.runInOwnerThread(&onLocalProcessExit, cast(intptr_t)pid);


### PR DESCRIPTION
This fixes the issue by moving the list of watched processes into a global and using `runInOwnerThread` to trigger the desired thread. It does require a global mutex for process list modifications which could be an issue.