### PR TITLE
Fix #116 - zombie processes with posix driver

### DIFF
--- a/source/eventcore/drivers/posix/processes.d
+++ b/source/eventcore/drivers/posix/processes.d
@@ -229,6 +229,8 @@ final class SignalEventDriverProcesses(Loop : PosixEventLoop) : EventDriverProce
 
     private void onProcessExit(int system_pid, int exitCode)
     {
+        import core.sys.posix.sys.wait : waitpid;
+
         auto pid = cast(ProcessID)system_pid;
         auto info = () @trusted { return pid in m_processes; } ();
 
@@ -237,6 +239,9 @@ final class SignalEventDriverProcesses(Loop : PosixEventLoop) : EventDriverProce
         if (info is null) {
             return;
         }
+
+        // call wait to avoid zombie process (returns immediatelly now)
+        (pid) @trusted { waitpid(pid, null, 0); }(system_pid);
 
         info.exited = true;
         info.exitCode = exitCode;


### PR DESCRIPTION
`waitpid` must be called to avoid zombie processes.
See http://man7.org/linux/man-pages/man2/waitpid.2.html