### PR TITLE
Test up to DMD 2.087.1/LDC 1.16.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,19 @@ d:
   # this way the overall test time gets cut down (GDC/LDC are a lot
   # slower tham DMD, so they should be started early), while still
   # catching most DMD version related build failures early
-  - dmd-2.082.0
+  # latest 4 versions plus the oldest supported version should be present
+  - dmd-2.087.1
   - dmd-2.076.1
-  - ldc-1.11.0
-  - ldc-1.10.0
-  - ldc-1.9.0
-  - ldc-1.8.0
-  - ldc-1.7.0
+  - ldc-1.16.0
+  - ldc-1.15.0
+  - ldc-1.14.0
+  - ldc-1.13.0
+  - ldc-1.12.0
   - ldc-1.6.0
   - dmd-beta
-  - dmd-2.081.2
-  - dmd-2.080.1
-  - dmd-2.079.0
-  - dmd-2.078.3
-  - dmd-2.077.1
+  - dmd-2.086.1
+  - dmd-2.085.1
+  - dmd-2.084.1
 
 env:
     - CONFIG=select

--- a/README.md
+++ b/README.md
@@ -27,18 +27,15 @@ Supported compilers
 
 The following compilers are tested and supported:
 
-- DMD 2.082.0
-- DMD 2.081.2
-- DMD 2.080.1
-- DMD 2.079.0
-- DMD 2.078.3
-- DMD 2.077.1
+- DMD 2.087.1
+- DMD 2.086.1
+- DMD 2.085.1
+- DMD 2.084.1
 - DMD 2.076.1
-- LDC 1.11.0
-- LDC 1.10.0
-- LDC 1.9.0
-- LDC 1.8.0
-- LDC 1.7.0
+- LDC 1.16.0
+- LDC 1.15.0
+- LDC 1.14.0
+- LDC 1.13.0
 - LDC 1.6.0
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,35 +2,31 @@ platform: x64
 environment:
  matrix:
   - DC: dmd
-    DVersion: 2.082.0
+    DVersion: 2.087.1
     arch: x64
     config: winapi
   - DC: dmd
-    DVersion: 2.082.0
+    DVersion: 2.087.1
     arch: x86
     config: winapi-optlink
   - DC: dmd
-    DVersion: 2.082.0
+    DVersion: 2.087.1
     arch: x86_mscoff
     config: winapi
   - DC: dmd
-    DVersion: 2.081.2
-    arch: x86_mscoff
-    config: winapi
-  - DC: dmd
-    DVersion: 2.080.1
-    arch: x86
-    config: select-optlink
-  - DC: dmd
-    DVersion: 2.079.0
-    arch: x86
-    config: select-optlink
-  - DC: dmd
-    DVersion: 2.078.3
+    DVersion: 2.086.1
     arch: x64
     config: winapi
   - DC: dmd
-    DVersion: 2.077.1
+    DVersion: 2.085.1
+    arch: x86_mscoff
+    config: winapi
+  - DC: dmd
+    DVersion: 2.084.1
+    arch: x86
+    config: winapi-optlink
+  - DC: dmd
+    DVersion: 2.083.1
     arch: x64
     config: winapi
   - DC: dmd
@@ -38,23 +34,19 @@ environment:
     arch: x64
     config: winapi
   - DC: ldc
-    DVersion: 1.11.0
+    DVersion: 1.16.0
     arch: x64
     config: winapi
   - DC: ldc
-    DVersion: 1.10.0
+    DVersion: 1.15.0
     arch: x64
     config: winapi
   - DC: ldc
-    DVersion: 1.9.0
+    DVersion: 1.14.0
     arch: x86
     config: winapi
   - DC: ldc
-    DVersion: 1.8.0
-    arch: x64
-    config: winapi
-  - DC: ldc
-    DVersion: 1.7.0
+    DVersion: 1.13.0
     arch: x64
     config: winapi
   - DC: ldc


### PR DESCRIPTION
Drops all but the latest 4 versions and the oldest supported version (2.076.1) to avoid increasing CI pressure.