### PR TITLE
Ensure that only the connect or the connection error callback is ever triggered.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -153,3 +153,4 @@ test_script:
  - echo %PATH%
  - '%DC% --version'
  - dub test --arch=%Darch% --compiler=%DC% --config=%CONFIG%
+ - for %%i in (tests\*.d) do echo %%i && dub --single %%i --arch=%Darch% --compiler=%DC% --override-config eventcore/%CONFIG% || exit /B 1

--- a/source/eventcore/drivers/winapi/sockets.d
+++ b/source/eventcore/drivers/winapi/sockets.d
@@ -552,8 +552,11 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 			}
 		}
 
-		if (mode == IOMode.immediate)
+		if (mode == IOMode.immediate) {
 			() @trusted { CancelIoEx(cast(HANDLE)cast(SOCKET)socket, cast(LPOVERLAPPED)&slot.read.overlapped); } ();
+			on_read_finish(socket, IOStatus.wouldBlock, 0, null);
+			return;
+		}
 
 		slot.read.callback = on_read_finish;
 		addRef(socket);
@@ -646,8 +649,11 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 			}
 		}
 
-		if (mode == IOMode.immediate)
+		if (mode == IOMode.immediate) {
 			() @trusted { CancelIoEx(cast(HANDLE)cast(SOCKET)socket, cast(LPOVERLAPPED)&slot.write.overlapped); } ();
+			on_write_finish(socket, IOStatus.wouldBlock, 0, null);
+			return;
+		}
 
 		slot.write.callback = on_write_finish;
 		addRef(socket);

--- a/tests/0-signal.d
+++ b/tests/0-signal.d
@@ -4,39 +4,42 @@
 +/
 module test;
 
-import eventcore.core;
 import std.stdio : writefln;
-import core.stdc.signal;
-import core.sys.posix.signal : SIGUSR1;
-import core.time : Duration, msecs;
 
-bool s_done;
+version (Linux) {
+	import eventcore.core;
+	import core.stdc.signal;
+	import core.sys.posix.signal : SIGUSR1;
+	import core.time : Duration, msecs;
 
-void main()
-{
-	version (OSX) writefln("Signals are not yet supported on macOS. Skipping test.");
-	else {
+	bool s_done;
 
-	auto id = eventDriver.signals.listen(SIGUSR1, (id, status, sig) {
-		assert(!s_done);
-		assert(status == SignalStatus.ok);
-		assert(sig == () @trusted { return SIGUSR1; } ());
-		eventDriver.signals.releaseRef(id);
-		s_done = true;
-	});
+	void main()
+	{
+		auto id = eventDriver.signals.listen(SIGUSR1, (id, status, sig) {
+			assert(!s_done);
+			assert(status == SignalStatus.ok);
+			assert(sig == () @trusted { return SIGUSR1; } ());
+			eventDriver.signals.releaseRef(id);
+			s_done = true;
+		});
 
-	auto tm = eventDriver.timers.create();
-	eventDriver.timers.set(tm, 500.msecs, 0.msecs);
-	eventDriver.timers.wait(tm, (tm) {
-		() @trusted { raise(SIGUSR1); } ();
-	});
+		auto tm = eventDriver.timers.create();
+		eventDriver.timers.set(tm, 500.msecs, 0.msecs);
+		eventDriver.timers.wait(tm, (tm) {
+			() @trusted { raise(SIGUSR1); } ();
+		});
 
-	ExitReason er;
-	do er = eventDriver.core.processEvents(Duration.max);
-	while (er == ExitReason.idle);
-	assert(er == ExitReason.outOfWaiters);
-	assert(s_done);
-	s_done = false;
-
+		ExitReason er;
+		do er = eventDriver.core.processEvents(Duration.max);
+		while (er == ExitReason.idle);
+		assert(er == ExitReason.outOfWaiters);
+		assert(s_done);
+		s_done = false;
+	}
+} else {
+	void main()
+	{
+		writefln("Signals are not yet supported on macOS/Windows. Skipping test.");
 	}
 }

--- a/tests/0-tcp-cancelconn.d
+++ b/tests/0-tcp-cancelconn.d
@@ -28,6 +28,7 @@ void main()
 	eventDriver.timers.wait(tm, (tm) {
 		assert(eventDriver.sockets.getConnectionState(sock) == ConnectionState.connecting);
 		eventDriver.sockets.cancelConnectStream(sock);
+		eventDriver.sockets.releaseRef(sock);
 		s_done = true;
 	});
 

--- a/tests/0-tcp-readwait.d
+++ b/tests/0-tcp-readwait.d
@@ -14,11 +14,7 @@ bool s_done;
 
 void main()
 {
-	version (OSX) {
-		import std.stdio;
-		writeln("This doesn't work on macOS. Skipping this test until it is determined that this special case should stay supported.");
-		return;
-	} else {
+	version (Linux) {
 
 	static ubyte[] pack1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
@@ -68,5 +64,9 @@ void main()
 	assert(s_done);
 	s_done = false;
 
+	} else {
+		import std.stdio;
+		writeln("This doesn't work on macOS/Windows. Skipping this test until it is determined that this special case should stay supported.");
+		return;
 	}
 }

--- a/tests/0-tcp.d
+++ b/tests/0-tcp.d
@@ -38,12 +38,16 @@ void main()
 			assert(bts == pack1.length);
 			assert(s_rbuf[0 .. pack1.length] == pack1);
 
-			print("Second write");
-			client.write!((status, bytes) {
-				print("Second write done");
-				assert(status == IOStatus.ok);
-				assert(bytes == pack2.length);
-			})(pack2, IOMode.once);
+			auto tmw = eventDriver.timers.create();
+			eventDriver.timers.set(tmw, 20.msecs, 0.msecs);
+			eventDriver.timers.wait(tmw, (tmw) {
+				print("Second write");
+				client.write!((status, bytes) {
+					print("Second write done");
+					assert(status == IOStatus.ok);
+					assert(bytes == pack2.length);
+				})(pack2, IOMode.once);
+			});
 
 			print("Second read");
 			incoming.read!((status, bts) {

--- a/tests/0-timer.d
+++ b/tests/0-timer.d
@@ -26,7 +26,7 @@ void main()
 		}
 
 		try {
-			assert(dur > 1200.msecs, (dur - 1200.msecs).toString());
+			assert(dur > 1200.msecs - 2.msecs, (dur - 1200.msecs).toString());
 			assert(dur < 1300.msecs, (dur - 1200.msecs).toString());
 		} catch (Exception e) assert(false, e.msg);
 
@@ -38,7 +38,7 @@ void main()
 			try {
 				auto dur = MonoTime.currTime() - s_startTime;
 				s_cnt++;
-				assert(dur > 300.msecs * s_cnt, (dur - 300.msecs * s_cnt).toString());
+				assert(dur > 300.msecs * s_cnt - 2.msecs, (dur - 300.msecs * s_cnt).toString());
 				assert(dur < 300.msecs * s_cnt + 100.msecs, (dur - 300.msecs * s_cnt).toString());
 				assert(s_cnt <= 3);
 

--- a/tests/0-udp.d
+++ b/tests/0-udp.d
@@ -20,6 +20,11 @@ void main()
 	static ubyte[] pack1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 	static ubyte[] pack2 = [4, 3, 2, 1, 0];
 
+	// Windows can not provide "immediate" semantics using the overlapped
+	// I/O API that is used
+	version (Windows) enum mode_immediate = IOMode.once;
+	else enum mode_immediate = IOMode.immediate;
+
 	auto baddr = new InternetAddress(0x7F000001, 40001);
 	auto anyaddr = new InternetAddress(0x7F000001, 0);
 	s_baseSocket = createDatagramSocket(baddr);
@@ -55,14 +60,14 @@ void main()
 				destroy(s_connectedSocket);
 				s_done = true;
 				log("done.");
-			})(s_rbuf, IOMode.immediate);
+			})(s_rbuf, mode_immediate);
 		});
 	})(s_rbuf, IOMode.once);
 	s_connectedSocket.send!((status, bytes) {
 		log("send1: %s %s", status, bytes);
 		assert(status == IOStatus.ok);
 		assert(bytes == 10);
-	})(pack1, IOMode.immediate);
+	})(pack1, mode_immediate);
 
 	ExitReason er;
 	do er = eventDriver.core.processEvents(Duration.max);

--- a/tests/issue-25-periodic-timers.d
+++ b/tests/issue-25-periodic-timers.d
@@ -44,7 +44,7 @@ void main()
 
 			auto dur = MonoTime.currTime() - s_startTime;
 			s_cnt++;
-			assert(dur > 300.msecs * s_cnt, (dur - 300.msecs * s_cnt).toString());
+			assert(dur > 300.msecs * s_cnt - 2.msecs, (dur - 300.msecs * s_cnt).toString());
 			assert(dur < 300.msecs * s_cnt + 100.msecs, (dur - 300.msecs * s_cnt).toString());
 			assert(s_cnt <= 5);
 


### PR DESCRIPTION
On macOS it could happen that both, onConnect and onConnectError, were triggered, resulting in seemingly overlapping connection attempts when they really were sequential. This in turn triggered a connection error leak test in vibe-core.