### PR TITLE
Fix API issues resulting in blocking the main thread

### DIFF
--- a/source/eventcore/driver.d
+++ b/source/eventcore/driver.d
@@ -1093,13 +1093,6 @@ struct FileChange {
 
 	/// Name of the changed file
 	const(char)[] name;
-
-	/** Determines if the changed entity is a file or a directory.
-
-		Note that depending on the platform this may not be accurate for
-		`FileChangeKind.removed`.
-	*/
-	bool isDirectory;
 }
 
 /** Describes a spawned process

--- a/source/eventcore/drivers/posix/pipes.d
+++ b/source/eventcore/drivers/posix/pipes.d
@@ -10,7 +10,7 @@ import std.algorithm : min, max;
 
 final class PosixEventDriverPipes(Loop : PosixEventLoop) : EventDriverPipes {
 @safe: /*@nogc:*/ nothrow:
-	import core.stdc.errno : errno, EAGAIN;
+	import core.stdc.errno : errno, EAGAIN, EINTR;
 	import core.sys.posix.unistd : close, read, write;
 	import core.sys.posix.fcntl;
 	import core.sys.posix.poll;
@@ -304,12 +304,21 @@ final class PosixEventDriverPipes(Loop : PosixEventLoop) : EventDriverPipes {
 		return false;
 	}
 
-	final override void close(PipeFD pipe)
+	final override void close(PipeFD pipe, PipeCloseCallback on_closed)
 	{
-		if (!isValid(pipe)) return;
+		if (!isValid(pipe)) {
+			on_closed(pipe, CloseStatus.invalidHandle);
+			return;
+		}
 
-		// TODO: Maybe actually close here instead of waiting for releaseRef?
-		close(cast(int)pipe);
+		int res;
+		do res = close(cast(int)pipe);
+		while (res != 0 && errno == EINTR);
+		m_loop.unregisterFD(pipe, EventMask.read|EventMask.write|EventMask.status);
+		m_loop.clearFD!PipeSlot(pipe);
+
+		if (on_closed)
+			on_closed(pipe, res == 0 ? CloseStatus.ok : CloseStatus.ioError);
 	}
 
 	override bool isValid(PipeFD handle)
@@ -337,10 +346,7 @@ final class PosixEventDriverPipes(Loop : PosixEventLoop) : EventDriverPipes {
 		nogc_assert(slot.common.refCount > 0, "Releasing reference to unreferenced pipe FD.");
 
 		if (--slot.common.refCount == 0) {
-			m_loop.unregisterFD(pipe, EventMask.read|EventMask.write|EventMask.status);
-			m_loop.clearFD!PipeSlot(pipe);
-
-			close(cast(int)pipe);
+			close(pipe, null);
 			return false;
 		}
 		return true;
@@ -386,8 +392,13 @@ final class DummyEventDriverPipes(Loop : PosixEventLoop) : EventDriverPipes {
 		assert(false, "TODO!");
 	}
 
-	override void close(PipeFD pipe)
+	override void close(PipeFD pipe, PipeCloseCallback on_closed)
 	{
+		if (!isValid(pipe)) {
+			on_closed(pipe, CloseStatus.invalidHandle);
+			return;
+		}
+
 		assert(false, "TODO!");
 	}
 

--- a/source/eventcore/drivers/posix/pipes.d
+++ b/source/eventcore/drivers/posix/pipes.d
@@ -350,7 +350,6 @@ final class PosixEventDriverPipes(Loop : PosixEventLoop) : EventDriverPipes {
 	@system {
 		return m_loop.rawUserDataImpl(fd, size, initialize, destroy);
 	}
->>>>>>> 568465d... Make the API robust against using invalid handles. Fixes #105.
 }
 
 final class DummyEventDriverPipes(Loop : PosixEventLoop) : EventDriverPipes {

--- a/source/eventcore/drivers/posix/processes.d
+++ b/source/eventcore/drivers/posix/processes.d
@@ -206,7 +206,7 @@ final class PosixEventDriverProcesses(Loop : PosixEventLoop) : EventDriverProces
 		m_driver.core.runInOwnerThread(&onLocalProcessExit, system_pid);
 	}
 
-	private static void onLocalProcessExit(intptr_t system_pid)
+	private static void onLocalProcessExit(int system_pid)
 	{
 		int exitCode;
 		ProcessWaitCallback[] callbacks;
@@ -214,12 +214,12 @@ final class PosixEventDriverProcesses(Loop : PosixEventLoop) : EventDriverProces
 		ProcessID pid;
 
 		PosixEventDriverProcesses driver;
-		lockedProcessInfoPlain(cast(int)system_pid, (info) {
+		lockedProcessInfoPlain(system_pid, (info) {
 			assert(info !is null);
 
 			exitCode = info.exitCode;
 			callbacks = info.callbacks;
-			pid = ProcessID(cast(int)system_pid, info.validationCounter);
+			pid = ProcessID(system_pid, info.validationCounter);
 			info.callbacks = null;
 
 			driver = info.driver;

--- a/source/eventcore/drivers/posix/watchers.d
+++ b/source/eventcore/drivers/posix/watchers.d
@@ -150,7 +150,6 @@ final class InotifyEventDriverWatchers(Events : EventDriverEvents) : EventDriver
 
 				ch.baseDirectory = m_watches[id].basePath;
 				ch.directory = subdir;
-				ch.isDirectory = (ev.mask & IN_ISDIR) != 0;
 				ch.name = name;
 				addRef(id); // assure that the id doesn't get invalidated until after the callback
 				auto cb = m_loop.m_fds[id].watcher.callback;
@@ -487,9 +486,9 @@ final class PollEventDriverWatchers(Events : EventDriverEvents) : EventDriverWat
 
 		@property size_t entryCount() const { return m_entryCount; }
 
-		private void addChange(FileChangeKind kind, Key key, bool is_dir)
+		private void addChange(FileChangeKind kind, Key key)
 		{
-			m_onChange(FileChange(kind, m_basePath, key.parent ? key.parent.path : "", key.name, is_dir));
+			m_onChange(FileChange(kind, m_basePath, key.parent ? key.parent.path : "", key.name));
 		}
 
 		private void scan(bool generate_changes)
@@ -506,12 +505,12 @@ final class PollEventDriverWatchers(Events : EventDriverEvents) : EventDriverWat
 			foreach (e; m_entries.byKeyValue) {
 				if (!e.key.parent || Key(e.key.parent.parent, e.key.parent.name) !in m_entries) {
 					if (generate_changes)
-						addChange(FileChangeKind.removed, e.key, e.value.isDir);
+						addChange(FileChangeKind.removed, e.key);
 				}
 			}
 
 			foreach (e; added)
-				addChange(FileChangeKind.added, Key(e.parent, e.name), e.isDir);
+				addChange(FileChangeKind.added, Key(e.parent, e.name));
 
 			swap(m_entries, new_entries);
 			m_entryCount = ec;
@@ -539,7 +538,7 @@ final class PollEventDriverWatchers(Events : EventDriverEvents) : EventDriverWat
 					} else {
 						if ((*pe).size != de.size || (*pe).lastChange != modified_time) {
 							if (generate_changes)
-								addChange(FileChangeKind.modified, key, (*pe).isDir);
+								addChange(FileChangeKind.modified, key);
 							(*pe).size = de.size;
 							(*pe).lastChange = modified_time;
 						}

--- a/source/eventcore/drivers/winapi/pipes.d
+++ b/source/eventcore/drivers/winapi/pipes.d
@@ -53,9 +53,13 @@ final class WinAPIEventDriverPipes : EventDriverPipes {
 		assert(false, "TODO!");
 	}
 
-	override void close(PipeFD pipe)
+	override void close(PipeFD pipe, PipeCloseCallback on_closed)
 	{
-		if (!isValid(pipe)) return;
+		if (!isValid(pipe)) {
+			if (on_closed)
+				on_closed(pipe, CloseStatus.invalidHandle);
+			return;
+		}
 
 		assert(false, "TODO!");
 	}

--- a/source/eventcore/drivers/winapi/watchers.d
+++ b/source/eventcore/drivers/winapi/watchers.d
@@ -193,10 +193,7 @@ final class WinAPIEventDriverWatchers : EventDriverWatchers {
 			ch.directory = dirName(path);
 			if (ch.directory == ".") ch.directory = "";
 			ch.name = baseName(path);
-			try ch.isDirectory = isDir(fullpath);
-			catch (Exception e) {} // FIXME: can happen if the base path is relative and the CWD has changed
-			if (ch.kind != FileChangeKind.modified || !ch.isDirectory)
-				slot.callback(id, ch);
+			slot.callback(id, ch);
 			if (fni.NextEntryOffset == 0 || !slot.callback) break;
 		}
 

--- a/source/eventcore/internal/ioworker.d
+++ b/source/eventcore/internal/ioworker.d
@@ -4,7 +4,7 @@ module eventcore.internal.ioworker;
 
 import eventcore.internal.utils;
 
-import std.parallelism : TaskPool;
+import std.parallelism : TaskPool, Task, task;
 
 
 IOWorkerPool acquireIOWorkerPool()
@@ -28,6 +28,14 @@ struct IOWorkerPool {
 	@property TaskPool pool() { return m_pool; }
 
 	alias pool this;
+
+	auto run(alias fun, ARGS...)(ARGS args)
+	{
+		auto t = task!(fun, ARGS)(args);
+		try m_pool.put(t);
+		catch (Exception e) assert(false, e.msg);
+		return t;
+	}
 }
 
 // Maintains a single thread pool shared by all driver instances (threads)

--- a/source/eventcore/internal/ioworker.d
+++ b/source/eventcore/internal/ioworker.d
@@ -1,0 +1,89 @@
+/** Provides a shared task pool for distributing tasks to worker threads.
+*/
+module eventcore.internal.ioworker;
+
+import eventcore.internal.utils;
+
+import std.parallelism : TaskPool;
+
+
+IOWorkerPool acquireIOWorkerPool()
+@safe nothrow {
+	return IOWorkerPool(true);
+}
+
+struct IOWorkerPool {
+	private {
+		TaskPool m_pool;
+	}
+
+	@safe nothrow:
+
+	private this(bool) { m_pool = StaticTaskPool.addRef(); }
+	~this() { if (m_pool) StaticTaskPool.releaseRef(); }
+	this(this) { if (m_pool) StaticTaskPool.addRef(); }
+
+	bool opCast(T)() const if (is(T == bool)) { return !!m_pool; }
+
+	@property TaskPool pool() { return m_pool; }
+
+	alias pool this;
+}
+
+// Maintains a single thread pool shared by all driver instances (threads)
+private struct StaticTaskPool {
+	import core.sync.mutex : Mutex;
+
+	private {
+		static shared Mutex m_mutex;
+		static __gshared TaskPool m_pool;
+		static __gshared int m_refCount = 0;
+	}
+
+	shared static this()
+	{
+		m_mutex = new shared Mutex;
+	}
+
+	static TaskPool addRef()
+	@trusted nothrow {
+		m_mutex.lock_nothrow();
+		scope (exit) m_mutex.unlock_nothrow();
+
+		if (!m_refCount++) {
+			try {
+				m_pool = mallocT!TaskPool(4);
+				m_pool.isDaemon = true;
+			} catch (Exception e) {
+				assert(false, e.msg);
+			}
+		}
+
+		return m_pool;
+	}
+
+	static void releaseRef()
+	@trusted nothrow {
+		TaskPool fin_pool;
+
+		{
+			m_mutex.lock_nothrow();
+			scope (exit) m_mutex.unlock_nothrow();
+
+			if (!--m_refCount) {
+				fin_pool = m_pool;
+				m_pool = null;
+			}
+		}
+
+		if (fin_pool) {
+			//log("finishing thread pool");
+			try {
+				fin_pool.finish(true);
+				freeT(fin_pool);
+			} catch (Exception e) {
+				//log("Failed to shut down file I/O thread pool.");
+			}
+		}
+	}
+}

--- a/tests/0-dirwatcher.d
+++ b/tests/0-dirwatcher.d
@@ -5,8 +5,9 @@
 module test;
 
 import eventcore.core;
+import std.file : exists, isDir, mkdir, remove, rmdirRecurse;
+import std.path : buildPath;
 import std.stdio : File, writefln;
-import std.file : exists, mkdir, remove, rmdirRecurse;
 import core.time : Duration, msecs;
 
 bool s_done;
@@ -23,6 +24,11 @@ void main()
 	scope (exit) rmdirRecurse(testDir);
 
 	auto id = eventDriver.watchers.watchDirectory(testDir, false, (id, ref change) {
+		try {
+			if (change.kind == FileChangeKind.modified && isDir(buildPath(change.baseDirectory, change.directory, change.name)))
+				return;
+		} catch (Exception e) assert(false, e.msg);
+
 		switch (s_cnt++) {
 			default:
 				import std.conv : to;

--- a/tests/0-file.d
+++ b/tests/0-file.d
@@ -36,13 +36,15 @@ void main()
 					assert(status == IOStatus.ok);
 					assert(nbytes == data.length - 5);
 					assert(dst == data);
-					eventDriver.files.close(f);
-					() @trusted {
-						scope (failure) assert(false);
-						remove("test.txt");
-					} ();
-					eventDriver.files.releaseRef(f);
-					s_done = true;
+					eventDriver.files.close(f, (f, s) {
+						assert(s == CloseStatus.ok);
+						() @trusted {
+							scope (failure) assert(false);
+							remove("test.txt");
+						} ();
+						eventDriver.files.releaseRef(f);
+						s_done = true;
+					});
 				});
 			});
 		});

--- a/tests/0-runinownerthread.d
+++ b/tests/0-runinownerthread.d
@@ -31,7 +31,7 @@ void main()
 
 void threadFunc(shared(NativeEventDriver) drv)
 {
-	drv.core.runInOwnerThread((id) {
+	drv.core.runInOwnerThread((int id) {
 		s_id = id;
 	}, 42);
 }


### PR DESCRIPTION
In some places, potentially blocking functions were called, most notably `close`/`CloseHandle`. The API needs to be adjusted to allow moving those calls to worker threads instead.