### PR TITLE
posix/dns: Fix SEGV on Musl when an error happens

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('eventcore', 'd',
     meson_version: '>=0.50',
-    version: '0.9.6'
+    version: '0.9.7'
 )
 
 project_soversion      = '0'

--- a/source/eventcore/drivers/posix/dns.d
+++ b/source/eventcore/drivers/posix/dns.d
@@ -180,7 +180,14 @@ final class EventDriverDNS_GAI(Events : EventDriverEvents, Signals : EventDriver
 					l.done = false;
 					if (i == m_maxHandle) m_maxHandle = lastmax;
 					m_events.loop.m_waiterCount--;
-					passToDNSCallback(DNSLookupID(i, l.validationCounter), cb, status, ai);
+					// An error happened, we have a return code
+					// We can directly call the delegate with it instead
+					// of calling `passToDNSCallback` (which doesn't support
+					// a `null` result on some platforms)
+					if (ai is null)
+						cb(DNSLookupID(i, l.validationCounter), status, null);
+					else
+						passToDNSCallback(DNSLookupID(i, l.validationCounter), cb, status, ai);
 				} else lastmax = i;
 			}
 		}


### PR DESCRIPTION
```
When an error happens, the 'struct addrinfo' (ai)
passed to 'passToDNSCallback' can be 'null'.
It end up being passed to 'freeaddrinfo'.
With glibc, or on OSX, it is okay to pass a 'null'
pointer to 'freeaddrinfo', however this will cause
a SIGSEGV on Musl.
The standard defines that 'freeaddrinfo' must accept
what was given to 'getaddrinfo', and 'getaddrinfo'
does not accept null pointer, so the musl behavior
is not wrong per se.
```