### PR TITLE
Fix host lookups hanging with concurrency

### DIFF
--- a/source/eventcore/drivers/posix/dns.d
+++ b/source/eventcore/drivers/posix/dns.d
@@ -150,7 +150,10 @@ final class EventDriverDNS_GAI(Events : EventDriverEvents, Signals : EventDriver
 		size_t lastmax;
 		foreach (i, ref l; m_lookups) {
 			if (i > m_maxHandle) break;
-			if (!atomicLoad(l.done)) continue;
+			if (!atomicLoad(l.done)) {
+				lastmax = i;
+				continue;
+			}
 			// synchronize the other fields in m_lookup with the lookup thread
 			atomicFence();
 


### PR DESCRIPTION
This addresses an extremely likely hang during startup of my app, while launching 8 concurrent requests in a 1-cpu vm.