### PR TITLE
dns: Set the result to null in cancelLookup()

### DIFF
--- a/source/eventcore/drivers/posix/dns.d
+++ b/source/eventcore/drivers/posix/dns.d
@@ -132,6 +132,7 @@ final class EventDriverDNS_GAI(Events : EventDriverEvents, Signals : EventDriver
 	{
 		if (!isValid(handle)) return;
 		m_lookups[handle].callback = null;
+		m_lookups[handle].result = null;
 		m_events.loop.m_waiterCount--;
 	}
 


### PR DESCRIPTION
Without this I get assertion failures when using `resolveHost` with timeouts.