### PR TITLE
DNS allocateHandle(): Don't return handle in use

### DIFF
--- a/source/eventcore/drivers/posix/dns.d
+++ b/source/eventcore/drivers/posix/dns.d
@@ -203,7 +203,7 @@ final class EventDriverDNS_GAI(Events : EventDriverEvents, Signals : EventDriver
 		assert(m_lookups.length <= int.max);
 		int id = cast(int)m_lookups.length;
 		foreach (i, ref l; m_lookups)
-			if (!l.callback) {
+			if (!l.callback && !l.result) {
 				id = cast(int)i;
 				break;
 			}


### PR DESCRIPTION
This is a second attempt at fixing the issue originally mentioned in PR #152.

I still can't figure out from the code flow how `result` can be set but where the `callback` isn't set. It doesn't seem like it should be possible.

So this fix is just an attempt at fixing the symptom, not the underlying problem.