### PR TITLE
suppressing socketStream warnings during shutdown initiated by SIGINT

### DIFF
--- a/source/eventcore/drivers/posix/driver.d
+++ b/source/eventcore/drivers/posix/driver.d
@@ -21,6 +21,7 @@ import eventcore.internal.utils;
 
 import core.time : MonoTime;
 import std.algorithm.comparison : among, min, max;
+import std.format : format;
 
 version (Posix) {
 	package alias sock_t = int;
@@ -116,13 +117,22 @@ final class PosixEventDriver(Loop : PosixEventLoop) : EventDriver {
 			return thname.length ? thname : "unknown";
 		}
 
-		if (m_loop.m_handleCount > 0) {
-			print("Warning (thread: %s): leaking eventcore driver because there are still active handles", getThreadName());
-			foreach (id, ref s; m_loop.m_fds)
-				if (!s.specific.hasType!(typeof(null)) && !(s.common.flags & FDFlags.internal))
-					print("   FD %s (%s)", id, s.specific.kind);
-			return false;
+		string leaking_handle_desc;
+		foreach (id, ref s; m_loop.m_fds) {
+			if (!s.specific.hasType!(typeof(null)) && !(s.common.flags & FDFlags.internal) &&
+			   (!s.specific.hasType!(StreamSocketSlot) || s.streamSocket.state == ConnectionState.connected))
+					try {
+						leaking_handle_desc ~= format!"   FD %s (%s)\n"(id, s.specific.kind);
+					} catch (Exception ex) { print("exception happened in Driver.dispose() during formatting"); }
 		}
+
+		if(leaking_handle_desc.length) {
+			print("Warning (thread: %s): leaking eventcore driver because there are still active handles", getThreadName());
+			print(leaking_handle_desc);
+		}
+
+		if (m_loop.m_handleCount > 0)
+			return false;
 
 		m_processes.dispose();
 		m_files.dispose();


### PR DESCRIPTION
When we termiate the application with a signal like SIGINT, the PosixEventDriver.dispose() reports that we have streamSockets that are leaking. Although it is true that those sockets are never closed during the shutdown initiated by SIGINT, they are mostly harmless as they are in a  CONNECTING state.

Fixing this is not straighforward(at least for me) so as a workaround, I modified to code to report warnings for streamSocket only if the streamSocket is in a CONNECTED state during shutdown.

here is a code to reproduce the issue:
```D
void main()
{
    runTask({
        requestHTTP("http://192.168.1.42:2828", // make sure this address is not reachable by ping
            (scope req) {
                req.method = HTTPMethod.POST;
                req.writeJsonBody(["name": "My Name"]);
            },
            (scope res) {
                logInfo("Response: %s", res.bodyReader.readAllUTF8());
            }
        );
	});

       runApplication();
}
```
1. compile it with "versions": [ "VibeHighEventPriority" ]
2. press CTRL+C
3. before my fix, you would see warnings even though those sockets are in a CONNECTING state during shutdown