### PR TITLE
Make eventcore compile with -preview=dip1000

### DIFF
--- a/source/eventcore/driver.d
+++ b/source/eventcore/driver.d
@@ -999,14 +999,14 @@ final class RefAddress : Address {
 	this() @safe nothrow {}
 	this(sockaddr* addr, socklen_t addr_len) @safe nothrow { set(addr, addr_len); }
 
-	override @property sockaddr* name() { return m_addr; }
-	override @property const(sockaddr)* name() const { return m_addr; }
-	override @property socklen_t nameLen() const { return m_addrLen; }
+	override @property sockaddr* name() scope { return m_addr; }
+	override @property const(sockaddr)* name() const scope { return m_addr; }
+	override @property socklen_t nameLen() const scope { return m_addrLen; }
 
 	void set(sockaddr* addr, socklen_t addr_len) @safe nothrow { m_addr = addr; m_addrLen = addr_len; }
 
 	void cap(socklen_t new_len)
-	@safe nothrow {
+	scope @safe nothrow {
 		assert(new_len <= m_addrLen, "Cannot grow size of a RefAddress.");
 		m_addrLen = new_len;
 	}

--- a/source/eventcore/drivers/posix/sockets.d
+++ b/source/eventcore/drivers/posix/sockets.d
@@ -117,7 +117,8 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 	{
 		assert(on_connect !is null);
 
-		auto sockfd = createSocket(address.addressFamily, SOCK_STREAM);
+		// @trusted to escape DIP1000's `scope` check
+		auto sockfd = () @trusted { return createSocket(address.addressFamily, SOCK_STREAM); }();
 		if (sockfd == -1) {
 			on_connect(StreamSocketFD.invalid, ConnectStatus.socketCreateFailure);
 			return StreamSocketFD.invalid;
@@ -221,7 +222,8 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 	alias listenStream = EventDriverSockets.listenStream;
 	final override StreamListenSocketFD listenStream(scope Address address, StreamListenOptions options, AcceptCallback on_accept)
 	{
-		auto sockfd = createSocket(address.addressFamily, SOCK_STREAM);
+		// @trusted to escape DIP1000's `scope` check
+		auto sockfd = () @trusted { return createSocket(address.addressFamily, SOCK_STREAM); }();
 		if (sockfd == -1) return StreamListenSocketFD.invalid;
 
 		auto succ = () @trusted {
@@ -703,7 +705,8 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 
 	package DatagramSocketFD createDatagramSocketInternal(scope Address bind_address, scope Address target_address, bool is_internal = true)
 	{
-		auto sockfd = createSocket(bind_address.addressFamily, SOCK_DGRAM);
+		// @trusted to escape DIP1000's `scope` check
+		auto sockfd = () @trusted { return createSocket(bind_address.addressFamily, SOCK_DGRAM); }();
 		if (sockfd == -1) return DatagramSocketFD.invalid;
 
 		if (bind_address && () @trusted { return bind(sockfd, bind_address.name, bind_address.nameLen); } () != 0) {
@@ -773,7 +776,8 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 	{
 		if (!isValid(socket)) return false;
 
-		switch (multicast_address.addressFamily) {
+		// @trusted to escape DIP1000's `scope` check
+		switch (() @trusted { return multicast_address.addressFamily; }()) {
 			default: assert(false, "Multicast only supported for IPv4/IPv6 sockets.");
 			case AddressFamily.INET:
 				struct ip_mreq {


### PR DESCRIPTION
I will most likely need to do more passes and adapt it according to vibe-core / vibe.d, and I think adding the CI in Vibe.d directly is the most sensible approach.