### PR TITLE
Fix fd leak when `cancelConnectStream` is called on timeout

### DIFF
--- a/source/eventcore/drivers/posix/sockets.d
+++ b/source/eventcore/drivers/posix/sockets.d
@@ -173,6 +173,10 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 			connectCallback = null;
 			m_loop.setNotifyCallback!(EventType.write)(sock, null);
 		}
+
+		m_loop.unregisterFD(sock, EventMask.read|EventMask.write);
+		m_loop.clearFD!StreamSocketSlot(sock);
+		closeSocket(cast(sock_t)sock);
 	}
 
 	final override StreamSocketFD adoptStream(int socket)

--- a/source/eventcore/drivers/winapi/sockets.d
+++ b/source/eventcore/drivers/winapi/sockets.d
@@ -106,6 +106,9 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 			connectCallback = null;
 			m_core.removeWaiter();
 		}
+
+		clearSocketSlot(sock);
+		invalidateSocket();
 	}
 
 	override StreamSocketFD adoptStream(int socket)


### PR DESCRIPTION
Fixes https://github.com/vibe-d/vibe-core/issues/331
But I'm not at all sure if this is the correct approach.

It doesn't matter if `releaseRef` is called before [cancelConnectStream](https://github.com/vibe-d/vibe-core/blob/55cd9022faec5a105aea42664afe5ff63cc53330/source/vibe/core/net.d#L218).

Within `cancelConnectStream` there is no call to anything that would check if num of references reaches 0 and closes the socket.
There is just a decrement in `setNotifyCallback` but no check.

So I took the straightest way to fix this case without touching anything else ;-)