### PR TITLE
Avoid spamming the debug=EventCoreLeakTrace hint for FD leaks.

### DIFF
--- a/source/eventcore/driver.d
+++ b/source/eventcore/driver.d
@@ -1027,18 +1027,7 @@ alias EventCallback = void delegate(EventID);
 alias SignalCallback = void delegate(SignalListenID, SignalStatus, int);
 alias TimerCallback = void delegate(TimerID);
 alias TimerCallback2 = void delegate(TimerID, bool fired);
-// Support for `-preview=in`
-// Using template because of https://issues.dlang.org/show_bug.cgi?id=21207
-private template FileChangesCallbackWorkaround ()
-{
-	static if (!is(typeof(mixin(q{(in ref int a) => a}))))
-		alias FileChangesCallbackWorkaround = void delegate(WatcherID, in FileChange change);
-	else
-		mixin(q{
-			alias FileChangesCallbackWorkaround = void delegate(WatcherID, in ref FileChange change);
-		});
-}
-alias FileChangesCallback = FileChangesCallbackWorkaround!();
+alias FileChangesCallback = void delegate(WatcherID, ref const FileChange change);
 
 alias ProcessWaitCallback = void delegate(ProcessID, int);
 @system alias DataInitializer = void function(void*) @nogc;

--- a/tests/0-dirwatcher-rec.d
+++ b/tests/0-dirwatcher-rec.d
@@ -76,7 +76,7 @@ void main()
 	assert(er == ExitReason.outOfWaiters);
 }
 
-void testCallback(WatcherID w, in ref FileChange ch)
+void testCallback(WatcherID w, ref const FileChange ch)
 @safe nothrow {
 	assert(w == watcher, "Wrong watcher generated a change");
 	pendingChanges ~= ch;


### PR DESCRIPTION
The hint is now only printed once at the end of the FD list.

Also rearranges hasPrintedHeader logic to be clearer to read.