### PR TITLE
Remove link dependency to libresolv.

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -5,7 +5,6 @@ copyright "Copyright © 2016-2018 Sönke Ludwig"
 
 targetType "library"
 
-libs "resolv" platform="linux"
 libs "ws2_32" "user32" platform="windows-dmd"
 
 dependency "taggedalgebraic" version=">=0.10.12 <0.12.0-0"


### PR DESCRIPTION
It appears that `__res_init` is available through glibc, so -lresolv is unnecessary. This removes a build issue when building for Android.