### PR TITLE
Meson: meson.build files updated, pkgc removed

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,14 +1,10 @@
-project('eventcore', 'd',
-	meson_version: '>=0.53',
+project(
+	'eventcore',
+	'd',
 	version: '0.9.13',
+	license: 'BSL-1.0',
+	meson_version: '>=0.53',
 )
-
-project_soversion      = '0'
-project_version_suffix = ''
-project_version        = meson.project_version()
-project_version_full   = project_version + project_version_suffix
-
-taggedalgebraic_dep = dependency('taggedalgebraic', version: ['>=0.10.12', '<0.12'])
 
 eventcore_build_versions = []
 eventcore_extra_deps = []
@@ -108,12 +104,55 @@ summary(
 	bool_yn: true
 )
 	
-
-source_root = meson.source_root()
-build_root = meson.build_root()
 subdir('source/eventcore')
 
 eventcore_dep = declare_dependency(
 	include_directories: include_directories('source'),
-	link_with: eventcore_lib
+	sources: sources,
+)
+
+taggedalgebraic_dep = subproject('taggedalgebraic').get_variable('library_dep')
+
+eventcore_lib = library(
+	'eventcore',
+	dependencies: [eventcore_dep, taggedalgebraic_dep, eventcore_extra_deps],
+	version: meson.project_version(),
+	install: true,
+	d_module_versions: eventcore_build_versions
+)
+
+test_exe = executable(
+	'eventcore_test',
+	dependencies: [eventcore_dep, taggedalgebraic_dep],
+	d_unittest: true,
+	d_args: meson.get_compiler('d').unittest_args(),
+	link_args: '-main',
+)
+
+test('test_eventcore', test_exe)
+
+# This is using install_subdir instead of install_headers, since
+# install_headers flattens the headers directory, it turns
+# ├ ...
+# ├ driver.d
+# ├ drivers
+# │  ├ libasync.d
+# │  ├ ...
+# │  └ winapi
+# │    └ ...
+# ├ ...
+# └ socket.d
+#
+# into
+#
+# ├ ...
+# ├ drivers.d
+# ├ libasync.d
+# ├ ...
+# └ socket.d
+#
+
+install_subdir(
+	'../',
+	install_dir: 'include/d/eventcore/eventcore',
 )

--- a/source/eventcore/meson.build
+++ b/source/eventcore/meson.build
@@ -1,4 +1,4 @@
-eventcore_src = [
+sources = files(
 	'core.d',
 	'driver.d',
 	'drivers/libasync.d',
@@ -33,60 +33,4 @@ eventcore_src = [
 	'internal/utils.d',
 	'internal/win32.d',
 	'socket.d',
-]
-
-eventcore_lib = library(
-	'eventcore',
-	eventcore_src,
-	version: project_version,
-	install: true,
-	include_directories: include_directories('../'),
-	dependencies: [taggedalgebraic_dep, eventcore_extra_deps],
-	d_module_versions: eventcore_build_versions
 )
-
-pkgc = import('pkgconfig')
-
-pkgc.generate(
-	eventcore_lib,
-	subdirs: 'd/eventcore',
-	d_module_versions: eventcore_build_versions
-)
-
-# This is using install_subdir instead of install_headers, since
-# install_headers flattens the headers directory, it turns
-# ├ ...
-# ├ driver.d
-# ├ drivers
-# │  ├ libasync.d
-# │  ├ ...
-# │  └ winapi
-# │    └ ...
-# ├ ...
-# └ socket.d
-# 
-# into
-# 
-# ├ ...
-# ├ drivers.d
-# ├ libasync.d
-# ├ ...
-# └ socket.d
-# 
-
-install_subdir(
-	'../',
-	install_dir: 'include/d/eventcore/eventcore',
-)
-
-test_exe = executable(
-	'eventcore_test',
-	eventcore_src,
-	include_directories: include_directories('../'),
-	d_unittest: true,
-	d_args: meson.get_compiler('d').unittest_args(),
-	link_args: '-main',
-	dependencies: taggedalgebraic_dep,
-)
-
-test('test_eventcore', test_exe)


### PR DESCRIPTION
Also removes dependency eventcore_dep from eventcore_lib:

```meson
eventcore_dep = declare_dependency(
	link_with: eventcore_lib
```