### PR TITLE
Do not retry if close(2) returns EINTR

### DIFF
--- a/source/eventcore/drivers/posix/pipes.d
+++ b/source/eventcore/drivers/posix/pipes.d
@@ -10,7 +10,7 @@ import std.algorithm : min, max;
 
 final class PosixEventDriverPipes(Loop : PosixEventLoop) : EventDriverPipes {
 @safe: /*@nogc:*/ nothrow:
-	import core.stdc.errno : errno, EAGAIN, EINTR;
+	import core.stdc.errno : errno, EAGAIN;
 	import core.sys.posix.unistd : close, read, write;
 	import core.sys.posix.fcntl;
 	import core.sys.posix.poll;
@@ -311,9 +311,7 @@ final class PosixEventDriverPipes(Loop : PosixEventLoop) : EventDriverPipes {
 			return;
 		}
 
-		int res;
-		do res = close(cast(int)pipe);
-		while (res != 0 && errno == EINTR);
+		int res = close(cast(int)pipe);
 		m_loop.unregisterFD(pipe, EventMask.read|EventMask.write|EventMask.status);
 		m_loop.clearFD!PipeSlot(pipe);
 

--- a/source/eventcore/drivers/threadedfile.d
+++ b/source/eventcore/drivers/threadedfile.d
@@ -193,9 +193,7 @@ final class ThreadedFileEventDriver(Events : EventDriverEvents) : EventDriverFil
 		}
 
 		// TODO: close may block and should be executed in a worker thread
-		int res;
-		do res = .close(cast(int)file.value);
-		while (res != 0 && errno == EINTR);
+		int res = .close(cast(int)file.value);
 
 		m_files[file.value] = FileInfo.init;
 


### PR DESCRIPTION
if a different thread opens a file at the wrong time and gets our file descriptor, we might end up closing the wrong file.

 ref: https://www.austingroupbugs.net/view.php?id=529