### PR TITLE
test: timer test robustly

### DIFF
--- a/tests/0-timer.d
+++ b/tests/0-timer.d
@@ -27,7 +27,7 @@ void main()
 
 		try {
 			assert(dur > 1200.msecs - 2.msecs, (dur - 1200.msecs).toString());
-			assert(dur < 1300.msecs, (dur - 1200.msecs).toString());
+			assert(dur < 1300.msecs + 100.msecs, (dur - 1200.msecs).toString());
 		} catch (Exception e) assert(false, e.msg);
 
 		s_startTime += dur;

--- a/tests/issue-25-periodic-timers.d
+++ b/tests/issue-25-periodic-timers.d
@@ -26,7 +26,7 @@ void main()
 			auto dur = MonoTime.currTime() - s_startTime;
 
 			assert(dur >= 1200.msecs, (dur - 1200.msecs).toString());
-			assert(dur < 1300.msecs, (dur - 1200.msecs).toString());
+			assert(dur < 1300.msecs + 100.msecs, (dur - 1200.msecs).toString());
 
 			timer1fired = true;
 		} catch (Exception e) {


### PR DESCRIPTION
unfortunately the timer test fails unreliable and is failling in CI on macOS.
So having 100 ms delay added.