### PR TITLE
Fix WinAPIEventDriverSockets(IOMode.immediate).

### DIFF
--- a/source/eventcore/drivers/winapi/sockets.d
+++ b/source/eventcore/drivers/winapi/sockets.d
@@ -283,6 +283,10 @@ final class WinAPIEventDriverSockets : EventDriverSockets {
 					on_read_finish(socket, IOStatus.wouldBlock, 0);
 					return;
 				}
+			} else if (err == WSAEWOULDBLOCK && mode == IOMode.immediate) {
+				resetBuffers();
+				on_read_finish(socket, IOStatus.wouldBlock, 0);
+				return;
 			} else {
 				resetBuffers();
 				auto st = handleReadError(err, *slot);


### PR DESCRIPTION
Yields WSAWOULDBLOCK instead of WSA_IO_PENDING, because "immediate" works without overlapped I/O. Results in IOStatus.wouldBlock instead of IOStatus.error and causes TCPConnection.waitForData(Ex) to not erroneously indicate a disconnect.