### PR TITLE
Fix compile error on Bionic/ARM

### DIFF
--- a/source/eventcore/drivers/threadedfile.d
+++ b/source/eventcore/drivers/threadedfile.d
@@ -224,7 +224,14 @@ final class ThreadedFileEventDriver(Events : EventDriverEvents) : EventDriverFil
 		version (Posix) {
 			// FIXME: do this in the thread pool
 
-			if (ftruncate(cast(int)file, size) != 0) {
+			static if (off_t.max < ulong.max) {
+				if (size > off_t.max) {
+					on_finish(file, IOStatus.error, 0);
+					return;
+				}
+			}
+
+			if (ftruncate(cast(int)file, cast(off_t)size) != 0) {
 				on_finish(file, IOStatus.error, 0);
 				return;
 			}


### PR DESCRIPTION
off_t is defined as 32-bit for 32-bit ARM targets.