### PR TITLE
Added IP_TRANSPARENT socket option for Linux only

### DIFF
--- a/source/eventcore/driver.d
+++ b/source/eventcore/driver.d
@@ -1095,6 +1095,8 @@ enum StreamListenOptions {
 	reusePort = 1<<0,
 	/// Avoids applying the `SO_REUSEADDR` flag
 	reuseAddress = 1<<1,
+	/// Applies the `IP_TRANSPARENT` flag
+	ipTransparent = 1<<2,
 	///
 	defaults = reuseAddress,
 }

--- a/source/eventcore/drivers/posix/sockets.d
+++ b/source/eventcore/drivers/posix/sockets.d
@@ -24,6 +24,8 @@ version (Posix) {
 	version (linux) enum SO_REUSEPORT = 15;
 	else enum SO_REUSEPORT = 0x200;
 
+	version (linux) enum IP_TRANSPARENT = 19;
+
 	static if (!is(typeof(O_CLOEXEC)))
 	{
 		version (linux) enum O_CLOEXEC = 0x80000;
@@ -248,6 +250,12 @@ final class PosixEventDriverSockets(Loop : PosixEventLoop) : EventDriverSockets 
 			version (Windows) {}
 			else {
 				if ((options & StreamListenOptions.reusePort) && setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT, &tmp_reuse, tmp_reuse.sizeof) != 0)
+					return false;
+			}
+
+			version (linux)
+			{
+				if ((options & StreamListenOptions.ipTransparent) && setsockopt(sockfd, IPPROTO_IP, IP_TRANSPARENT, &tmp_reuse, tmp_reuse.sizeof) != 0)
 					return false;
 			}
 


### PR DESCRIPTION
Add support for IP_TRANSPARENT socket options. Only Linux provides this option. Pull request for related changes to vibe-core follows merging of these changes.