### PR TITLE
Avoid possible assertion error on macOS/BSD at shutdown

### DIFF
--- a/source/eventcore/internal/utils.d
+++ b/source/eventcore/internal/utils.d
@@ -27,6 +27,21 @@ void print(ARGS...)(string str, ARGS args)
 	s.r.put('\n');
 }
 
+void printWarningWithStackTrace(ARGS...)(string str, ARGS args)
+@trusted @nogc nothrow {
+	try print(str, args);
+	catch (Exception e) {}
+	debug {
+		try throw new Exception("");
+		catch (Exception e) {
+			try {
+				print("Call stack:");
+				foreach (ln; e.info) print("%s", ln);
+			} catch (Exception e2) {}
+		}
+	}
+}
+
 T mallocT(T, ARGS...)(ARGS args)
 {
 	import core.stdc.stdlib : malloc;


### PR DESCRIPTION
The garbage collector termination might trigger an operation that causes a kqueue request to be made, while the eventcore driver will already have been destroyed in the `shared static ~this` of vibe-core. This changes a hard assertion failure into a warning output