### PR TITLE
Avoid using the FSEventStream API on iOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
 
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Install D compiler
-              uses: dlang-community/setup-dlang@v1
+              uses: dlang-community/setup-dlang@v2
               with:
                   compiler: ${{ matrix.dc }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,22 +15,22 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest, macOS-latest]
+                os: [ubuntu-latest, windows-latest, macos-13]
                 dc: [dmd-latest, ldc-latest, dmd-2.086.0, ldc-1.16.0, ldc-1.17.0]
                 arch: [x86_64]
                 config: [select, epoll, cfrunloop, winapi]
                 exclude:
                   - {os: ubuntu-latest, config: cfrunloop}
                   - {os: ubuntu-latest, config: winapi}
-                  - {os: macOS-latest, config: epoll}
-                  - {os: macOS-latest, config: winapi}
+                  - {os: macos-13, config: epoll}
+                  - {os: macos-13, config: winapi}
                   - {os: windows-latest, config: cfrunloop}
                   - {os: windows-latest, config: epoll}
                   # macOS fails up to FE 2.086.x, so we test on a slightly newer
                   # version instead
                   # "dyld: lazy symbol binding failed: Symbol not found: _dyld_enumerate_tlv_storage"
-                  - {os: macOS-latest, dc: dmd-2.086.0}
-                  - {os: macOS-latest, dc: ldc-1.16.0}
+                  - {os: macos-13, dc: dmd-2.086.0}
+                  - {os: macos-13, dc: ldc-1.16.0}
                   - {os: windows-latest, dc: ldc-1.16.0, config: select}
                   - {os: windows-latest, dc: ldc-1.17.0}
                   - {os: ubuntu-latest, dc: ldc-1.17.0}

--- a/source/eventcore/drivers/posix/driver.d
+++ b/source/eventcore/drivers/posix/driver.d
@@ -55,8 +55,10 @@ final class PosixEventDriver(Loop : PosixEventLoop) : EventDriver {
 		version (Posix) alias PipeDriver = PosixEventDriverPipes!Loop;
 		else alias PipeDriver = DummyEventDriverPipes!Loop;
 		version (linux) alias WatcherDriver = InotifyEventDriverWatchers!EventsDriver;
-		else version (EventcoreCFRunLoopDriver) alias WatcherDriver = FSEventsEventDriverWatchers!EventsDriver;
-		else alias WatcherDriver = PollEventDriverWatchers!EventsDriver;
+		else version (EventcoreCFRunLoopDriver) {
+			version (OSX) alias WatcherDriver = FSEventsEventDriverWatchers!EventsDriver;
+			else alias WatcherDriver = PollEventDriverWatchers!EventsDriver;
+		} else alias WatcherDriver = PollEventDriverWatchers!EventsDriver;
 		version (Posix) alias ProcessDriver = PosixEventDriverProcesses!Loop;
 		else alias ProcessDriver = DummyEventDriverProcesses!Loop;
 

--- a/source/eventcore/drivers/posix/watchers.d
+++ b/source/eventcore/drivers/posix/watchers.d
@@ -4,7 +4,6 @@ module eventcore.drivers.posix.watchers;
 import eventcore.driver;
 import eventcore.drivers.posix.driver;
 import eventcore.internal.utils : mallocT, freeT, nogc_assert;
-import eventcore.internal.corefoundation : isAppleOS;
 
 
 final class InotifyEventDriverWatchers(Events : EventDriverEvents) : EventDriverWatchers
@@ -201,7 +200,7 @@ final class InotifyEventDriverWatchers(Events : EventDriverEvents) : EventDriver
 	}
 }
 
-static if (isAppleOS)
+version (OSX) // NOTE: Although this works on iOS, too, this is a private API there
 final class FSEventsEventDriverWatchers(Events : EventDriverEvents) : EventDriverWatchers {
 @safe: /*@nogc:*/ nothrow:
 	import eventcore.internal.corefoundation;


### PR DESCRIPTION
This API is treated as private on non-macOS Apple operating systems. For now, fall back to the polling event driver.