### PR TITLE
Fix possible segfault in `lockedProcessInfo`

### DIFF
--- a/source/eventcore/drivers/posix/processes.d
+++ b/source/eventcore/drivers/posix/processes.d
@@ -323,7 +323,7 @@ final class PosixEventDriverProcesses(Loop : PosixEventLoop) : EventDriverProces
 	private static void lockedProcessInfo(ProcessID pid, scope void delegate(ProcessInfo*) nothrow @safe fn)
 	{
 		lockedProcessInfoPlain(cast(int)pid.value, (pi) {
-			fn(pi.validationCounter == pid.validationCounter ? pi : null);
+			fn(pi && pi.validationCounter == pid.validationCounter ? pi : null);
 		});
 	}
 


### PR DESCRIPTION
`lockedProcessInfoPlain` can pass `null` pointer which ends up with a `SIGSEGV`.