### PR TITLE
Remove FILE_FLAG_BACKUP_SEMANTICS when opening regular files

### DIFF
--- a/source/eventcore/drivers/winapi/files.d
+++ b/source/eventcore/drivers/winapi/files.d
@@ -34,7 +34,7 @@ final class WinAPIEventDriverFiles : EventDriverFiles {
 		auto handle = () @trusted {
 			scope (failure) assert(false);
 			return CreateFileW(path.toUTF16z, access, shareMode, null, creation,
-				FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, null);
+				FILE_FLAG_OVERLAPPED, null);
 		} ();
 		auto errorcode = GetLastError();
 		if (handle == INVALID_HANDLE_VALUE)
@@ -82,7 +82,7 @@ final class WinAPIEventDriverFiles : EventDriverFiles {
 			HANDLE handle = () @trusted {
 				scope (failure) assert(false);
 				return CreateFileW(path.toUTF16z, access, share_mode, null, creation,
-					FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, null);
+					FILE_FLAG_OVERLAPPED, null);
 			} ();
 			DWORD errorcode = GetLastError();
 			if (handle != INVALID_HANDLE_VALUE) {


### PR DESCRIPTION
This is only necessary for opening directories and looks to be a copy/paste artifact.