### PR TITLE
Make recursive inotify directory watchers fully asynchronous

### DIFF
--- a/source/eventcore/drivers/posix/driver.d
+++ b/source/eventcore/drivers/posix/driver.d
@@ -156,6 +156,7 @@ final class PosixEventDriver(Loop : PosixEventLoop) : EventDriver {
 			return false;
 
 		m_processes.dispose();
+		m_watchers.dispose();
 		m_files.dispose();
 		m_dns.dispose();
 		m_core.dispose();

--- a/source/eventcore/drivers/posix/watchers.d
+++ b/source/eventcore/drivers/posix/watchers.d
@@ -78,7 +78,7 @@ final class InotifyEventDriverWatchers(Events : EventDriverEvents) : EventDriver
 		m_loop.setNotifyCallback!(EventType.read)(cast(FD)ret, &onChanges);
 
 		m_mutex.lock_nothrow();
-		m_watchers[ret] = WatcherState(basePath: path, recursive: recursive);
+		m_watchers[ret] = WatcherState(null, null, path, recursive);
 		m_mutex.unlock_nothrow();
 		addWatchRecursively(ret, -1, null);
 


### PR DESCRIPTION
This avoids blocking the calling thread for possibly long periods of time when iterating over large directory hierarchies to create watches for each directory.