### PR TITLE
Fix wrong path-filename separation on Windows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,24 +15,20 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest, macos-13]
+                os: [ubuntu-latest, windows-latest]
                 dc: [dmd-latest, ldc-latest, dmd-2.087.1, ldc-1.17.0]
                 arch: [x86_64]
-                config: [select, epoll, cfrunloop, winapi, uring]
+                config: [select, epoll, winapi, uring]
                 exclude:
-                  - {os: ubuntu-latest, config: cfrunloop}
                   - {os: ubuntu-latest, config: winapi}
-                  - {os: macos-13, config: epoll}
-                  - {os: macos-13, config: uring}
-                  - {os: macos-13, config: winapi}
-                  - {os: windows-latest, config: cfrunloop}
                   - {os: windows-latest, config: epoll}
                   - {os: windows-latest, config: uring}
-                  - {os: macos-13, dc: dmd-2.087.1}
                   - {os: windows-latest, dc: ldc-1.17.0}
                   - {os: ubuntu-latest, dc: ldc-1.17.0}
                   - {os: ubuntu-latest, dc: dmd-2.087.1, config: uring}
                 include:
+                  - {os: macos-latest, dc: ldc-latest, arch: aarch64, config: cfrunloop}
+                  - {os: macos-latest, dc: ldc-latest, arch: aarch64, config: kqueue}
                   - {os: windows-latest, dc: ldc-latest, arch: x86, config: winapi}
                   - {os: windows-latest, dc: dmd-latest, arch: x86_mscoff, config: winapi}
 

--- a/source/eventcore/drivers/winapi/watchers.d
+++ b/source/eventcore/drivers/winapi/watchers.d
@@ -128,7 +128,7 @@ final class WinAPIEventDriverWatchers : EventDriverWatchers {
 		import std.algorithm.iteration : map;
 		import std.conv : to;
 		import std.file : isDir;
-		import std.path : dirName, baseName, buildPath;
+		import std.string : lastIndexOfAny;
 
 		auto handle = overlapped.hEvent; // *file* handle
 		auto gslot = () @trusted { return &WinAPIEventDriver.threadInstance.core.m_handles[handle]; } ();
@@ -189,10 +189,14 @@ final class WinAPIEventDriverWatchers : EventDriverWatchers {
 				if (fni.NextEntryOffset > 0) continue;
 				else break;
 			}
-			auto fullpath = buildPath(slot.directory, path);
-			ch.directory = dirName(path);
+			sizediff_t sep = -1;
+			try sep = path.lastIndexOfAny("/\\");
+			catch (Exception e) {}
+			if (sep >= 0) {
+				ch.directory = path[0 .. sep];
+				ch.name = path[sep+1 .. $];
+			} else ch.name = path;
 			if (ch.directory == ".") ch.directory = "";
-			ch.name = baseName(path);
 			slot.callback(id, ch);
 			if (fni.NextEntryOffset == 0 || !slot.callback) break;
 		}


### PR DESCRIPTION
An (invalid) Windows path, such as "foo\\bar:baz" is getting separated at the colon instead of at the backslash by Phobos' dirName/baseName functions. To fix this, this switches to lastIndexOfAny.